### PR TITLE
Revise Xbox 360 controller documentation

### DIFF
--- a/docs/devices/xbox360.md
+++ b/docs/devices/xbox360.md
@@ -51,12 +51,13 @@ The device stream is a bidirectional, raw TCP connection with fixed-size packets
 
 ### Input State
 
-- 14-byte packets, little-endian layout:
+- 20-byte packets, little-endian layout:
   - Buttons: uint32 (4 bytes, bitfield)
   - Triggers: LT, RT: uint8, uint8 (2 bytes)  
     0-255 (0=not pressed, 255=fully pressed)
   - Sticks: LX, LY, RX, RY: int16 each (8 bytes)  
     0 is center, -32768 is min, 32767 is max
+  - Reserved: there are 6 reserved bytes at the end of the report. For most subtypes, these will be zeroed, but a few subtypes do put data here.
 
 ### Rumble Feedback
 


### PR DESCRIPTION
Updated Xbox 360 controller documentation to note that the input state is 20 bytes and has the reserved bytes at the end

## Description
<!-- Describe your changes in detail -->
Noted that in my previous changes id forgotten to document the reserved bytes


## How Has This Been Tested?
<!-- Please describe how you tested your changes -->
- [ ] Tested with hardware (specify configuration)
- [ ] Unit tests
- [x] Code review only

## Type of Change
<!-- What types of changes does your code introduce? Put an `x` in all boxes that apply -->
- [ ] Bug fix (non-breaking change addressing an issue)
- [ ] New feature (non-breaking change adding functionality)
- [ ] Breaking change (fix or feature causing existing functionality to change)
- [x] Documentation update

## Checklist
<!-- Put an `x` in all the boxes that apply -->
- [ ] My code follows the code style of this project
- [x] I have updated the documentation accordingly
- [ ] I have added tests to cover my changes
- [ ] All new and existing tests passed
