### PR TITLE
Add Nintendo Switch 2 Pro controller support

### DIFF
--- a/README.md
+++ b/README.md
@@ -59,6 +59,7 @@ Beyond device emulation, VIIPER can proxy real USB devices for traffic inspectio
 - HID Keyboard with N-key rollover and LED feedback; see [Devices › Keyboard](docs/devices/keyboard.md)
 - HID Mouse with 5 buttons and horizontal/vertical wheel; see [Devices › Mouse](docs/devices/mouse.md)
 - PS4 controller emulation; see [Devices › DualShock 4 Controller](docs/devices/dualshock4.md)
+- Nintendo Switch 2 Pro Controller emulation; see [Devices › Switch 2 Pro Controller](docs/devices/ns2pro.md)
 - 🔜 Future plugin system allows for more device types (other gamepads, specialized HID)
 
 ## 🔌 Requirements

--- a/device/ns2pro/commands.go
+++ b/device/ns2pro/commands.go
@@ -1,0 +1,131 @@
+package ns2pro
+
+import "encoding/binary"
+
+func (d *NS2Pro) handleBulkOut(out []byte) {
+	if len(out) < 8 {
+		return
+	}
+	cmd := out[0]
+	seq := out[2]
+	sub := out[3]
+
+	switch cmd {
+	case 0x02:
+		d.handleFlashCommand(seq, sub, out)
+	case 0x03:
+		d.handleUSBCommand(seq, sub, out)
+	case 0x0C:
+		d.handleFeatureCommand(seq, sub, out)
+	case 0x09:
+		d.handlePlayerLEDCommand(seq, sub, out)
+	default:
+		d.enqueueResponse(commandHeader(cmd, seq, sub))
+	}
+}
+
+func (d *NS2Pro) handlePlayerLEDCommand(seq, sub uint8, out []byte) {
+	if sub == 0x07 && len(out) >= 9 {
+		d.emitOutput(OutputState{
+			Flags:         OutputFlagLED,
+			PlayerLedMask: out[8],
+		})
+	}
+	d.enqueueResponse(commandHeader(0x09, seq, sub))
+}
+
+func (d *NS2Pro) handleFlashCommand(seq, sub uint8, out []byte) {
+	if sub != 0x01 || len(out) < 16 {
+		d.enqueueResponse(commandHeader(0x02, seq, sub))
+		return
+	}
+
+	address := binary.LittleEndian.Uint32(out[12:16])
+	resp := make([]byte, 0x50)
+	copy(resp[0:8], commandHeader(0x02, seq, sub))
+	resp[8] = 0x40
+	binary.LittleEndian.PutUint32(resp[12:16], address)
+	copy(resp[16:], minimalFlashBlock(address))
+	d.enqueueResponse(resp)
+}
+
+func (d *NS2Pro) handleUSBCommand(seq, sub uint8, out []byte) {
+	switch sub {
+	case 0x03:
+		if len(out) >= 9 {
+			d.usbReportsEnabled = out[8] != 0
+		}
+		d.enqueueResponse(append(commandHeader(0x03, seq, sub), 0x01, 0x00, 0x00, 0x00))
+	case 0x0A:
+		if len(out) >= 9 {
+			switch out[8] {
+			case ReportIDCommon, ReportIDPro:
+				d.activeReportID = out[8]
+			}
+		}
+		d.enqueueResponse(commandHeader(0x03, seq, sub))
+	case 0x0D:
+		d.usbReportsEnabled = true
+		d.enqueueResponse(append(commandHeader(0x03, seq, sub), 0x01, 0x00, 0x00, 0x00))
+	default:
+		d.enqueueResponse(commandHeader(0x03, seq, sub))
+	}
+}
+
+func (d *NS2Pro) handleFeatureCommand(seq, sub uint8, out []byte) {
+	flags := uint8(0)
+	if len(out) >= 9 {
+		flags = out[8]
+	}
+
+	switch sub {
+	case 0x01:
+		payload := make([]byte, 12)
+		copy(payload[4:], featureInfo(flags))
+		d.enqueueResponse(append(commandHeader(0x0C, seq, sub), payload...))
+	case 0x02:
+		d.featureMask = flags
+		d.enqueueResponse(append(commandHeader(0x0C, seq, sub), 0x00, 0x00, 0x00, 0x00))
+	case 0x03:
+		d.featureMask = 0
+		d.featureFlags = 0
+		d.enqueueResponse(append(commandHeader(0x0C, seq, sub), 0x00, 0x00, 0x00, 0x00))
+	case 0x04:
+		d.featureFlags |= d.maskedFeatures(flags)
+		d.enqueueResponse(append(commandHeader(0x0C, seq, sub), 0x00, 0x00, 0x00, 0x00))
+	case 0x05:
+		d.featureFlags &^= d.maskedFeatures(flags)
+		d.enqueueResponse(append(commandHeader(0x0C, seq, sub), 0x00, 0x00, 0x00, 0x00))
+	default:
+		d.enqueueResponse(append(commandHeader(0x0C, seq, sub), 0x00, 0x00, 0x00, 0x00))
+	}
+}
+
+func (d *NS2Pro) maskedFeatures(flags uint8) uint8 {
+	if d.featureMask == 0 {
+		return flags
+	}
+	return flags & d.featureMask
+}
+
+func featureInfo(flags uint8) []byte {
+	out := make([]byte, 8)
+	for _, entry := range featureInfoMap {
+		if flags&entry.feature != 0 {
+			out[entry.index] = entry.value
+		}
+	}
+	return out
+}
+
+var featureInfoMap = []struct {
+	feature uint8
+	index   int
+	value   byte
+}{
+	{FeatureButtons, 0, 0x07},
+	{FeatureSticks, 1, 0x07},
+	{FeatureIMU, 2, 0x01},
+	{FeatureMouse, 4, 0x03},
+	{FeatureRumble, 5, 0x03},
+}

--- a/device/ns2pro/const.go
+++ b/device/ns2pro/const.go
@@ -1,9 +1,11 @@
 package ns2pro
 
 const (
-	DefaultVID    = 0x057E
-	DefaultPID    = 0x2069
-	DefaultSerial = "00"
+	DefaultVID                 = 0x057E
+	DefaultPID                 = 0x2069
+	DefaultSerialEnding        = "00"
+	DefaultSerial              = "VIIPER-NS2PRO-" + DefaultSerialEnding
+	DefaultBatteryVolts uint16 = 3800
 )
 
 const (
@@ -22,7 +24,7 @@ const (
 const (
 	InputReportSize  = 64
 	OutputReportSize = 64
-	InputWireSize    = 27
+	InputWireSize    = 24
 	OutputRumbleSize = 32
 	OutputWireSize   = 34
 )
@@ -33,11 +35,10 @@ const (
 )
 
 const (
-	StickMin     uint16 = 0
-	StickCenter  uint16 = 0x0800
-	StickMax     uint16 = 0x0FFF
-	BatteryMax   uint8  = 9
-	BatteryVolts uint16 = 3800
+	StickMin    uint16 = 0
+	StickCenter uint16 = 0x0800
+	StickMax    uint16 = 0x0FFF
+	BatteryMax  uint8  = 9
 )
 
 const (

--- a/device/ns2pro/const.go
+++ b/device/ns2pro/const.go
@@ -1,0 +1,74 @@
+package ns2pro
+
+const (
+	DefaultVID    = 0x057E
+	DefaultPID    = 0x2069
+	DefaultSerial = "00"
+)
+
+const (
+	EndpointHIDIn   = 0x81
+	EndpointHIDOut  = 0x01
+	EndpointBulkOut = 0x02
+	EndpointBulkIn  = 0x82
+)
+
+const (
+	ReportIDCommon = 0x05
+	ReportIDPro    = 0x09
+	ReportIDOutput = 0x02
+)
+
+const (
+	InputReportSize  = 64
+	OutputReportSize = 64
+	InputWireSize    = 27
+	OutputRumbleSize = 32
+	OutputWireSize   = 34
+)
+
+const (
+	OutputFlagRumble = 0x01
+	OutputFlagLED    = 0x02
+)
+
+const (
+	StickMin     uint16 = 0
+	StickCenter  uint16 = 0x0800
+	StickMax     uint16 = 0x0FFF
+	BatteryMax   uint8  = 9
+	BatteryVolts uint16 = 3800
+)
+
+const (
+	FeatureButtons = 0x01
+	FeatureSticks  = 0x02
+	FeatureIMU     = 0x04
+	FeatureMouse   = 0x10
+	FeatureRumble  = 0x20
+)
+
+const (
+	ButtonB uint32 = 1 << iota
+	ButtonA
+	ButtonY
+	ButtonX
+	ButtonR
+	ButtonZR
+	ButtonPlus
+	ButtonRightStick
+	ButtonDown
+	ButtonRight
+	ButtonLeft
+	ButtonUp
+	ButtonL
+	ButtonZL
+	ButtonMinus
+	ButtonLeftStick
+	ButtonHome
+	ButtonCapture
+	ButtonGR
+	ButtonGL
+	ButtonC
+	ButtonHeadset
+)

--- a/device/ns2pro/descriptor.go
+++ b/device/ns2pro/descriptor.go
@@ -84,7 +84,7 @@ func MakeDescriptor() usb.Descriptor {
 			0: "\u0409",
 			1: "Nintendo",
 			2: "Switch 2 Pro Controller",
-			3: DefaultSerial,
+			3: DefaultSerialEnding,
 			4: "Nintendo Switch 2 Pro Controller",
 			5: "Nintendo Switch 2 Pro Controller",
 			6: "Pro Controller",

--- a/device/ns2pro/descriptor.go
+++ b/device/ns2pro/descriptor.go
@@ -1,0 +1,149 @@
+package ns2pro
+
+import (
+	"github.com/Alia5/VIIPER/usb"
+	"github.com/Alia5/VIIPER/usb/hid"
+)
+
+const microsoftOS10VendorCode = 0x20
+
+const microsoftOS10DeviceInterfaceGUID = "{7D8F1E5C-9D89-4E0D-A2F0-6D10F1F89A8F}"
+
+func MakeDescriptor() usb.Descriptor {
+	return usb.Descriptor{
+		Device: usb.DeviceDescriptor{
+			BcdUSB:             0x0200,
+			BDeviceClass:       0xEF,
+			BDeviceSubClass:    0x02,
+			BDeviceProtocol:    0x01,
+			BMaxPacketSize0:    0x40,
+			IDVendor:           DefaultVID,
+			IDProduct:          DefaultPID,
+			BcdDevice:          0x0200,
+			IManufacturer:      0x01,
+			IProduct:           0x02,
+			ISerialNumber:      0x03,
+			BNumConfigurations: 0x01,
+			Speed:              2,
+		},
+		Configuration: usb.ConfigurationDescriptor{
+			BConfigurationValue: 0x01,
+			IConfiguration:      0x04,
+			BMAttributes:        0xC0,
+			BMaxPower:           0xFA,
+		},
+		MicrosoftOS10: &usb.MicrosoftOS10Descriptor{
+			VendorCode:          microsoftOS10VendorCode,
+			InterfaceNumber:     0x01,
+			CompatibleID:        "WINUSB",
+			DeviceInterfaceGUID: microsoftOS10DeviceInterfaceGUID,
+		},
+		Interfaces: []usb.InterfaceConfig{
+			{
+				Descriptor: usb.InterfaceDescriptor{
+					BInterfaceNumber:   0x00,
+					BAlternateSetting:  0x00,
+					BNumEndpoints:      0x02,
+					BInterfaceClass:    0x03,
+					BInterfaceSubClass: 0x00,
+					BInterfaceProtocol: 0x00,
+					IInterface:         0x05,
+				},
+				HID: &usb.HIDFunction{
+					Descriptor: usb.HIDDescriptor{
+						BcdHID:       0x0111,
+						BCountryCode: 0x00,
+						Descriptors: []usb.HIDSubDescriptor{
+							{Type: usb.ReportDescType},
+						},
+					},
+					ReportDescriptor: reportDescriptor,
+				},
+				Endpoints: []usb.EndpointDescriptor{
+					{BEndpointAddress: EndpointHIDIn, BMAttributes: 0x03, WMaxPacketSize: 64, BInterval: 4},
+					{BEndpointAddress: EndpointHIDOut, BMAttributes: 0x03, WMaxPacketSize: 64, BInterval: 4},
+				},
+			},
+			{
+				Descriptor: usb.InterfaceDescriptor{
+					BInterfaceNumber:   0x01,
+					BAlternateSetting:  0x00,
+					BNumEndpoints:      0x02,
+					BInterfaceClass:    0xFF,
+					BInterfaceSubClass: 0x00,
+					BInterfaceProtocol: 0x00,
+					IInterface:         0x06,
+				},
+				Endpoints: []usb.EndpointDescriptor{
+					{BEndpointAddress: EndpointBulkOut, BMAttributes: 0x02, WMaxPacketSize: 64, BInterval: 0},
+					{BEndpointAddress: EndpointBulkIn, BMAttributes: 0x02, WMaxPacketSize: 64, BInterval: 0},
+				},
+			},
+		},
+		Strings: map[uint8]string{
+			0: "\u0409",
+			1: "Nintendo",
+			2: "Switch 2 Pro Controller",
+			3: DefaultSerial,
+			4: "Nintendo Switch 2 Pro Controller",
+			5: "Nintendo Switch 2 Pro Controller",
+			6: "Pro Controller",
+		},
+	}
+}
+
+var reportDescriptor = hid.ReportDescriptor{
+	Items: []hid.Item{
+		hidShort(hid.ItemTypeGlobal, 0x0, 0x01),
+		hidShort(hid.ItemTypeLocal, 0x0, 0x05),
+		hidShort(hid.ItemTypeMain, 0xA, 0x01),
+		hidShort(hid.ItemTypeGlobal, 0x8, ReportIDCommon),
+		hidShort(hid.ItemTypeGlobal, 0x0, 0xFF),
+		hidShort(hid.ItemTypeLocal, 0x0, 0x01),
+		hidShort(hid.ItemTypeGlobal, 0x1, 0x00),
+		hidShort(hid.ItemTypeGlobal, 0x2, 0xFF, 0x00),
+		hidShort(hid.ItemTypeGlobal, 0x9, 0x3F),
+		hidShort(hid.ItemTypeGlobal, 0x7, 0x08),
+		hidShort(hid.ItemTypeMain, 0x8, 0x02),
+		hidShort(hid.ItemTypeGlobal, 0x8, ReportIDPro),
+		hidShort(hid.ItemTypeLocal, 0x0, 0x01),
+		hidShort(hid.ItemTypeGlobal, 0x9, 0x02),
+		hidShort(hid.ItemTypeMain, 0x8, 0x02),
+		hidShort(hid.ItemTypeGlobal, 0x0, 0x09),
+		hidShort(hid.ItemTypeLocal, 0x1, 0x01),
+		hidShort(hid.ItemTypeLocal, 0x2, 0x15),
+		hidShort(hid.ItemTypeGlobal, 0x2, 0x01),
+		hidShort(hid.ItemTypeGlobal, 0x9, 0x15),
+		hidShort(hid.ItemTypeGlobal, 0x7, 0x01),
+		hidShort(hid.ItemTypeMain, 0x8, 0x02),
+		hidShort(hid.ItemTypeGlobal, 0x9, 0x01),
+		hidShort(hid.ItemTypeGlobal, 0x7, 0x03),
+		hidShort(hid.ItemTypeMain, 0x8, 0x03),
+		hidShort(hid.ItemTypeGlobal, 0x0, 0x01),
+		hidShort(hid.ItemTypeLocal, 0x0, 0x01),
+		hidShort(hid.ItemTypeMain, 0xA, 0x00),
+		hidShort(hid.ItemTypeLocal, 0x0, 0x30),
+		hidShort(hid.ItemTypeLocal, 0x0, 0x31),
+		hidShort(hid.ItemTypeLocal, 0x0, 0x33),
+		hidShort(hid.ItemTypeLocal, 0x0, 0x35),
+		hidShort(hid.ItemTypeGlobal, 0x2, 0xFF, 0x0F),
+		hidShort(hid.ItemTypeGlobal, 0x9, 0x04),
+		hidShort(hid.ItemTypeGlobal, 0x7, 0x0C),
+		hidShort(hid.ItemTypeMain, 0x8, 0x02),
+		hidShort(hid.ItemTypeMain, 0xC),
+		hidShort(hid.ItemTypeGlobal, 0x0, 0xFF),
+		hidShort(hid.ItemTypeLocal, 0x0, 0x02),
+		hidShort(hid.ItemTypeGlobal, 0x2, 0xFF, 0x00),
+		hidShort(hid.ItemTypeGlobal, 0x9, 0x34),
+		hidShort(hid.ItemTypeGlobal, 0x7, 0x08),
+		hidShort(hid.ItemTypeMain, 0x8, 0x02),
+		hidShort(hid.ItemTypeGlobal, 0x8, ReportIDOutput),
+		hidShort(hid.ItemTypeLocal, 0x0, 0x01),
+		hidShort(hid.ItemTypeGlobal, 0x9, 0x3F),
+		hidShort(hid.ItemTypeMain, 0x9, 0x02),
+		hidShort(hid.ItemTypeMain, 0xC),
+	}}
+
+func hidShort(itemType hid.ItemType, tag uint8, data ...uint8) hid.AnyItem {
+	return hid.AnyItem{Type: itemType, Tag: tag, Data: hid.Data(data)}
+}

--- a/device/ns2pro/device.go
+++ b/device/ns2pro/device.go
@@ -2,6 +2,8 @@
 package ns2pro
 
 import (
+	"encoding/json"
+	"fmt"
 	"sync"
 
 	"github.com/Alia5/VIIPER/device"
@@ -12,12 +14,11 @@ import (
 type NS2Pro struct {
 	stateMu        sync.Mutex
 	inputState     *InputState
+	metaState      *MetaState
 	outputMu       sync.RWMutex
 	outputCallback func(OutputState)
 	outputVersion  uint64
 	descriptor     usb.Descriptor
-
-	batteryVolts uint16
 
 	protoMu           sync.Mutex
 	activeReportID    uint8
@@ -31,13 +32,26 @@ type NS2Pro struct {
 }
 
 func New(o *device.CreateOptions) (*NS2Pro, error) {
+	metaState := defaultMetaState()
+	if o != nil && o.DeviceSpecific != "" {
+		if err := json.Unmarshal([]byte(o.DeviceSpecific), metaState); err != nil {
+			return nil, fmt.Errorf("invalid device specific JSON: %w", err)
+		}
+	}
+
 	d := &NS2Pro{
 		inputState:     defaultInputState(),
+		metaState:      metaState,
 		descriptor:     MakeDescriptor(),
 		activeReportID: ReportIDPro,
 		featureFlags:   FeatureButtons | FeatureSticks,
-		batteryVolts:   BatteryVolts,
 	}
+	serialEnding := DefaultSerialEnding
+	if len(metaState.SerialNumber) >= 2 {
+		serialEnding = metaState.SerialNumber[len(metaState.SerialNumber)-2:]
+	}
+	d.descriptor.Strings[3] = serialEnding
+
 	if o != nil {
 		if o.IDVendor != nil {
 			d.descriptor.Device.IDVendor = *o.IDVendor
@@ -69,6 +83,19 @@ func (d *NS2Pro) UpdateInputState(state InputState) {
 	d.stateMu.Lock()
 	defer d.stateMu.Unlock()
 	d.inputState = &state
+}
+
+func (d *NS2Pro) SetMetaState(meta MetaState) {
+	d.stateMu.Lock()
+	defer d.stateMu.Unlock()
+	d.metaState = &meta
+	if d.descriptor.Strings != nil {
+		serialEnding := DefaultSerialEnding
+		if len(meta.SerialNumber) >= 2 {
+			serialEnding = meta.SerialNumber[len(meta.SerialNumber)-2:]
+		}
+		d.descriptor.Strings[3] = serialEnding
+	}
 }
 
 func (d *NS2Pro) HandleTransfer(ep uint32, dir uint32, out []byte) []byte {
@@ -139,7 +166,20 @@ func (d *NS2Pro) GetDescriptor() *usb.Descriptor {
 }
 
 func (d *NS2Pro) GetDeviceSpecificArgs() map[string]any {
-	return nil
+	d.stateMu.Lock()
+	defer d.stateMu.Unlock()
+	if d.metaState == nil {
+		return map[string]any{}
+	}
+	b, err := json.Marshal(d.metaState)
+	if err != nil {
+		return map[string]any{}
+	}
+	var out map[string]any
+	if err := json.Unmarshal(b, &out); err != nil {
+		return map[string]any{}
+	}
+	return out
 }
 
 func (d *NS2Pro) nextInputReport() []byte {
@@ -152,6 +192,7 @@ func (d *NS2Pro) nextInputReport() []byte {
 func (d *NS2Pro) inputReportForID(reportID uint8) []byte {
 	d.stateMu.Lock()
 	st := *d.inputState
+	meta := *d.metaState
 	d.stateMu.Unlock()
 
 	d.protoMu.Lock()
@@ -166,13 +207,22 @@ func (d *NS2Pro) inputReportForID(reportID uint8) []byte {
 		if features&FeatureIMU != 0 {
 			d.motionTimestamp += 4000
 		}
-		report = st.buildCommonReport(d.reportCounter32, d.motionTimestamp, features, d.batteryVolts)
+		report = st.buildCommonReport(d.reportCounter32, d.motionTimestamp, features, meta)
 	default:
 		d.reportCounter8++
-		report = st.buildProReport(d.reportCounter8, features)
+		report = st.buildProReport(d.reportCounter8, features, meta)
 	}
 	d.protoMu.Unlock()
 	return report
+}
+
+func (d *NS2Pro) serialNumber() string {
+	d.stateMu.Lock()
+	defer d.stateMu.Unlock()
+	if d.metaState == nil {
+		return ""
+	}
+	return d.metaState.SerialNumber
 }
 
 func (d *NS2Pro) handleOutputReport(out []byte) {

--- a/device/ns2pro/device.go
+++ b/device/ns2pro/device.go
@@ -1,0 +1,228 @@
+// Package ns2pro provides a Nintendo Switch 2 Pro Controller compatible HID device.
+package ns2pro
+
+import (
+	"sync"
+
+	"github.com/Alia5/VIIPER/device"
+	"github.com/Alia5/VIIPER/usb"
+	"github.com/Alia5/VIIPER/usbip"
+)
+
+type NS2Pro struct {
+	stateMu        sync.Mutex
+	inputState     *InputState
+	outputMu       sync.RWMutex
+	outputCallback func(OutputState)
+	outputVersion  uint64
+	descriptor     usb.Descriptor
+
+	batteryVolts uint16
+
+	protoMu           sync.Mutex
+	activeReportID    uint8
+	featureMask       uint8
+	featureFlags      uint8
+	usbReportsEnabled bool
+	reportCounter32   uint32
+	reportCounter8    uint8
+	motionTimestamp   uint32
+	bulkInQueue       [][]byte
+}
+
+func New(o *device.CreateOptions) (*NS2Pro, error) {
+	d := &NS2Pro{
+		inputState:     defaultInputState(),
+		descriptor:     MakeDescriptor(),
+		activeReportID: ReportIDPro,
+		featureFlags:   FeatureButtons | FeatureSticks,
+		batteryVolts:   BatteryVolts,
+	}
+	if o != nil {
+		if o.IDVendor != nil {
+			d.descriptor.Device.IDVendor = *o.IDVendor
+		}
+		if o.IDProduct != nil {
+			d.descriptor.Device.IDProduct = *o.IDProduct
+		}
+	}
+	return d, nil
+}
+
+func (d *NS2Pro) SetOutputCallback(f func(OutputState)) func() {
+	d.outputMu.Lock()
+	d.outputVersion++
+	version := d.outputVersion
+	d.outputCallback = f
+	d.outputMu.Unlock()
+
+	return func() {
+		d.outputMu.Lock()
+		if d.outputVersion == version {
+			d.outputCallback = nil
+		}
+		d.outputMu.Unlock()
+	}
+}
+
+func (d *NS2Pro) UpdateInputState(state InputState) {
+	d.stateMu.Lock()
+	defer d.stateMu.Unlock()
+	d.inputState = &state
+}
+
+func (d *NS2Pro) HandleTransfer(ep uint32, dir uint32, out []byte) []byte {
+	switch {
+	case dir == usbip.DirIn && ep == 1:
+		return d.nextInputReport()
+	case dir == usbip.DirIn && ep == 2:
+		return d.popBulkIn()
+	case dir == usbip.DirOut && ep == 1:
+		d.handleOutputReport(out)
+	case dir == usbip.DirOut && ep == 2:
+		d.handleBulkOut(out)
+	}
+	return nil
+}
+
+func (d *NS2Pro) HandleControl(bmRequestType, bRequest uint8, wValue, wIndex uint16, wLength uint16, data []byte) ([]byte, bool) {
+	const (
+		hidGetReport = 0x01
+		hidSetReport = 0x09
+	)
+	const (
+		reportTypeInput  = 0x01
+		reportTypeOutput = 0x02
+	)
+
+	reportType := uint8(wValue >> 8)
+	reportID := uint8(wValue)
+
+	if bmRequestType == 0xA1 && bRequest == hidGetReport && reportType == reportTypeInput {
+		switch reportID {
+		case ReportIDCommon, ReportIDPro, 0:
+			return d.inputReportForID(reportID), true
+		}
+	}
+
+	if bmRequestType == 0x21 && bRequest == hidSetReport && reportType == reportTypeOutput && reportID == ReportIDOutput {
+		d.handleOutputReport(data)
+		return nil, true
+	}
+
+	if isAudioClassRequest(bmRequestType) {
+		switch bRequest {
+		case 0x01: // SET_CUR
+			return nil, true
+		case 0x81, 0x82, 0x83, 0x84: // GET_CUR/MIN/MAX/RES
+			return make([]byte, wLength), true
+		}
+	}
+
+	return nil, false
+}
+
+func isAudioClassRequest(bmRequestType uint8) bool {
+	const (
+		requestTypeMask   = 0x60
+		requestClass      = 0x20
+		recipientMask     = 0x1F
+		recipientIface    = 0x01
+		recipientEndpoint = 0x02
+	)
+	return bmRequestType&requestTypeMask == requestClass &&
+		(bmRequestType&recipientMask == recipientIface || bmRequestType&recipientMask == recipientEndpoint)
+}
+
+func (d *NS2Pro) GetDescriptor() *usb.Descriptor {
+	return &d.descriptor
+}
+
+func (d *NS2Pro) GetDeviceSpecificArgs() map[string]any {
+	return nil
+}
+
+func (d *NS2Pro) nextInputReport() []byte {
+	d.protoMu.Lock()
+	reportID := d.activeReportID
+	d.protoMu.Unlock()
+	return d.inputReportForID(reportID)
+}
+
+func (d *NS2Pro) inputReportForID(reportID uint8) []byte {
+	d.stateMu.Lock()
+	st := *d.inputState
+	d.stateMu.Unlock()
+
+	d.protoMu.Lock()
+	if reportID == 0 {
+		reportID = d.activeReportID
+	}
+	features := d.featureFlags
+	var report []byte
+	switch reportID {
+	case ReportIDCommon:
+		d.reportCounter32++
+		if features&FeatureIMU != 0 {
+			d.motionTimestamp += 4000
+		}
+		report = st.buildCommonReport(d.reportCounter32, d.motionTimestamp, features, d.batteryVolts)
+	default:
+		d.reportCounter8++
+		report = st.buildProReport(d.reportCounter8, features)
+	}
+	d.protoMu.Unlock()
+	return report
+}
+
+func (d *NS2Pro) handleOutputReport(out []byte) {
+	if len(out) == 0 {
+		return
+	}
+
+	payload := out
+	if out[0] == ReportIDOutput {
+		payload = out[1:]
+	} else if len(out) != OutputRumbleSize {
+		return
+	}
+	if len(payload) < OutputRumbleSize {
+		return
+	}
+
+	feedback := OutputState{}
+	copy(feedback.LeftRumble[:], payload[0:16])
+	copy(feedback.RightRumble[:], payload[16:32])
+	feedback.Flags = OutputFlagRumble
+	d.emitOutput(feedback)
+}
+
+func (d *NS2Pro) emitOutput(feedback OutputState) {
+	d.outputMu.RLock()
+	callback := d.outputCallback
+	d.outputMu.RUnlock()
+	if callback != nil {
+		callback(feedback)
+	}
+}
+
+func (d *NS2Pro) enqueueResponse(resp []byte) {
+	d.protoMu.Lock()
+	defer d.protoMu.Unlock()
+	d.bulkInQueue = append(d.bulkInQueue, append([]byte(nil), resp...))
+}
+
+func (d *NS2Pro) popBulkIn() []byte {
+	d.protoMu.Lock()
+	defer d.protoMu.Unlock()
+	if len(d.bulkInQueue) == 0 {
+		return nil
+	}
+	chunk := d.bulkInQueue[0]
+	d.bulkInQueue = d.bulkInQueue[1:]
+	return append([]byte(nil), chunk...)
+}
+
+func commandHeader(cmd, seq, sub uint8) []byte {
+	return []byte{cmd, 0x01, seq, sub, 0x10, 0x78, 0x00, 0x00}
+}

--- a/device/ns2pro/flash.go
+++ b/device/ns2pro/flash.go
@@ -4,7 +4,7 @@ func minimalFlashBlock(address uint32) []byte {
 	block := make([]byte, 0x40)
 	switch address {
 	case 0x13000:
-		copy(block[2:], []byte("VIIPER-NS2PRO-00"))
+		copy(block[2:], []byte(DefaultSerial))
 	case 0x13080, 0x130C0:
 		encodeStickCalibration(block[0x28:], StickCenter, StickCenter, 2047, 2047, 2048, 2048)
 	case 0x13040, 0x13100, 0x1FC040, 0x1FC080:

--- a/device/ns2pro/flash.go
+++ b/device/ns2pro/flash.go
@@ -1,0 +1,24 @@
+package ns2pro
+
+func minimalFlashBlock(address uint32) []byte {
+	block := make([]byte, 0x40)
+	switch address {
+	case 0x13000:
+		copy(block[2:], []byte("VIIPER-NS2PRO-00"))
+	case 0x13080, 0x130C0:
+		encodeStickCalibration(block[0x28:], StickCenter, StickCenter, 2047, 2047, 2048, 2048)
+	case 0x13040, 0x13100, 0x1FC040, 0x1FC080:
+		// Zeroed data is intentional: no gyro/accel bias and no user calibration magic.
+	default:
+	}
+	return block
+}
+
+func encodeStickCalibration(out []byte, neutralX, neutralY, maxX, maxY, minX, minY uint16) {
+	if len(out) < 9 {
+		return
+	}
+	packStick12(out[0:3], neutralX, neutralY)
+	packStick12(out[3:6], maxX, maxY)
+	packStick12(out[6:9], minX, minY)
+}

--- a/device/ns2pro/handler.go
+++ b/device/ns2pro/handler.go
@@ -1,6 +1,7 @@
 package ns2pro
 
 import (
+	"encoding/json"
 	"fmt"
 	"io"
 	"log/slog"
@@ -17,12 +18,68 @@ func init() {
 
 type handler struct{}
 
+var serials = map[string]struct{}{}
+
 func (h *handler) CreateDevice(o *device.CreateOptions) (usb.Device, error) {
+	if o == nil {
+		o = &device.CreateOptions{}
+	}
+
+	metaState := *defaultMetaState()
+	if o.DeviceSpecific != "" {
+		if err := json.Unmarshal([]byte(o.DeviceSpecific), &metaState); err != nil {
+			return nil, fmt.Errorf("invalid device specific JSON: %w", err)
+		}
+	}
+
+	serial := metaState.SerialNumber
+	if serial == "" {
+		serial = DefaultSerial
+	}
+	if _, ok := serials[serial]; ok {
+		if len(serial) < 2 {
+			serial = DefaultSerial
+		}
+		for i := 1; i < 16; i++ {
+			newSerial := fmt.Sprintf("%s%02X", serial[:len(serial)-2], i)
+			if _, exists := serials[newSerial]; !exists {
+				serial = newSerial
+				break
+			}
+		}
+	}
+
+	metaState.SerialNumber = serial
+	serials[serial] = struct{}{}
+
+	b, err := json.Marshal(metaState)
+	if err != nil {
+		return nil, fmt.Errorf("marshal meta state: %w", err)
+	}
+	o.DeviceSpecific = string(b)
+
 	return New(o)
 }
 
 func (h *handler) StreamHandler() api.StreamHandlerFunc {
 	return func(conn net.Conn, devPtr *usb.Device, logger *slog.Logger) error {
+		defer func() {
+			if devPtr == nil || *devPtr == nil {
+				return
+			}
+			ns2, ok := (*devPtr).(*NS2Pro)
+			if !ok {
+				slog.Warn("device is not ns2pro on disconnect")
+				return
+			}
+			serial := ns2.serialNumber()
+			if serial == "" {
+				return
+			}
+			delete(serials, serial)
+			slog.Debug("ns2pro disconnected, serial released", "serial", serial)
+		}()
+
 		if devPtr == nil || *devPtr == nil {
 			return fmt.Errorf("nil device")
 		}
@@ -63,5 +120,16 @@ func (h *handler) StreamHandler() api.StreamHandlerFunc {
 }
 
 func (h *handler) UpdateMetaState(meta string, dev *usb.Device) error {
+	ns2, ok := (*dev).(*NS2Pro)
+	if !ok {
+		return fmt.Errorf("%w: expected ns2pro", device.ErrWrongDeviceType)
+	}
+
+	metaState := *defaultMetaState()
+	if err := json.Unmarshal([]byte(meta), &metaState); err != nil {
+		return fmt.Errorf("unmarshal meta state: %w", err)
+	}
+
+	ns2.SetMetaState(metaState)
 	return nil
 }

--- a/device/ns2pro/handler.go
+++ b/device/ns2pro/handler.go
@@ -1,0 +1,67 @@
+package ns2pro
+
+import (
+	"fmt"
+	"io"
+	"log/slog"
+	"net"
+
+	"github.com/Alia5/VIIPER/device"
+	"github.com/Alia5/VIIPER/internal/server/api"
+	"github.com/Alia5/VIIPER/usb"
+)
+
+func init() {
+	api.RegisterDevice("ns2pro", &handler{})
+}
+
+type handler struct{}
+
+func (h *handler) CreateDevice(o *device.CreateOptions) (usb.Device, error) {
+	return New(o)
+}
+
+func (h *handler) StreamHandler() api.StreamHandlerFunc {
+	return func(conn net.Conn, devPtr *usb.Device, logger *slog.Logger) error {
+		if devPtr == nil || *devPtr == nil {
+			return fmt.Errorf("nil device")
+		}
+		ns2, ok := (*devPtr).(*NS2Pro)
+		if !ok {
+			return fmt.Errorf("device is not ns2pro")
+		}
+
+		clearOutputCallback := ns2.SetOutputCallback(func(feedback OutputState) {
+			data, err := feedback.MarshalBinary()
+			if err != nil {
+				logger.Error("failed to marshal ns2pro feedback", "error", err)
+				return
+			}
+			if _, err := conn.Write(data); err != nil {
+				logger.Error("failed to send ns2pro feedback", "error", err)
+			}
+		})
+		defer clearOutputCallback()
+
+		buf := make([]byte, InputWireSize)
+		for {
+			if _, err := io.ReadFull(conn, buf); err != nil {
+				if err == io.EOF {
+					logger.Info("client disconnected")
+					return nil
+				}
+				return fmt.Errorf("read input state: %w", err)
+			}
+
+			var state InputState
+			if err := state.UnmarshalBinary(buf); err != nil {
+				return fmt.Errorf("unmarshal input state: %w", err)
+			}
+			ns2.UpdateInputState(state)
+		}
+	}
+}
+
+func (h *handler) UpdateMetaState(meta string, dev *usb.Device) error {
+	return nil
+}

--- a/device/ns2pro/inputstate.go
+++ b/device/ns2pro/inputstate.go
@@ -6,7 +6,7 @@ import (
 )
 
 // nolint
-// viiper:wire ns2pro c2s buttons:u32 lx:u16 ly:u16 rx:u16 ry:u16 accelX:i16 accelY:i16 accelZ:i16 gyroX:i16 gyroY:i16 gyroZ:i16 batteryLevel:u8 charging:bool externalPower:bool
+// viiper:wire ns2pro c2s buttons:u32 lx:u16 ly:u16 rx:u16 ry:u16 accelX:i16 accelY:i16 accelZ:i16 gyroX:i16 gyroY:i16 gyroZ:i16
 type InputState struct {
 	Buttons uint32
 
@@ -15,20 +15,31 @@ type InputState struct {
 
 	AccelX, AccelY, AccelZ int16
 	GyroX, GyroY, GyroZ    int16
-
-	BatteryLevel  uint8
-	Charging      bool
-	ExternalPower bool
 }
 
 func defaultInputState() *InputState {
 	return &InputState{
-		LX:            StickCenter,
-		LY:            StickCenter,
-		RX:            StickCenter,
-		RY:            StickCenter,
+		LX: StickCenter,
+		LY: StickCenter,
+		RX: StickCenter,
+		RY: StickCenter,
+	}
+}
+
+type MetaState struct {
+	SerialNumber  string `json:"serial_number"`
+	BatteryLevel  uint8  `json:"battery_level"`
+	Charging      bool   `json:"charging"`
+	ExternalPower bool   `json:"external_power"`
+	BatteryVolts  uint16 `json:"battery_volts"`
+}
+
+func defaultMetaState() *MetaState {
+	return &MetaState{
+		SerialNumber:  DefaultSerial,
 		BatteryLevel:  BatteryMax,
 		ExternalPower: true,
+		BatteryVolts:  DefaultBatteryVolts,
 	}
 }
 
@@ -45,13 +56,6 @@ func (s *InputState) MarshalBinary() ([]byte, error) {
 	binary.LittleEndian.PutUint16(b[18:20], uint16(s.GyroX))
 	binary.LittleEndian.PutUint16(b[20:22], uint16(s.GyroY))
 	binary.LittleEndian.PutUint16(b[22:24], uint16(s.GyroZ))
-	b[24] = s.BatteryLevel
-	if s.Charging {
-		b[25] = 1
-	}
-	if s.ExternalPower {
-		b[26] = 1
-	}
 	return b, nil
 }
 
@@ -70,9 +74,6 @@ func (s *InputState) UnmarshalBinary(data []byte) error {
 	s.GyroX = int16(binary.LittleEndian.Uint16(data[18:20]))
 	s.GyroY = int16(binary.LittleEndian.Uint16(data[20:22]))
 	s.GyroZ = int16(binary.LittleEndian.Uint16(data[22:24]))
-	s.BatteryLevel = data[24]
-	s.Charging = data[25] != 0
-	s.ExternalPower = data[26] != 0
 	return nil
 }
 
@@ -105,7 +106,7 @@ func (o *OutputState) UnmarshalBinary(data []byte) error {
 	return nil
 }
 
-func (s InputState) buildCommonReport(counter, motionTimestamp uint32, features uint8, batteryVolts uint16) []byte {
+func (s InputState) buildCommonReport(counter, motionTimestamp uint32, features uint8, meta MetaState) []byte {
 	b := make([]byte, InputReportSize)
 	b[0] = ReportIDCommon
 	binary.LittleEndian.PutUint32(b[1:5], counter)
@@ -115,8 +116,8 @@ func (s InputState) buildCommonReport(counter, motionTimestamp uint32, features 
 	packStick12(b[11:14], s.LX, s.LY)
 	packStick12(b[14:17], s.RX, s.RY)
 
-	binary.LittleEndian.PutUint16(b[0x20:0x22], batteryVolts)
-	b[0x22] = chargingState(s)
+	binary.LittleEndian.PutUint16(b[0x20:0x22], meta.BatteryVolts)
+	b[0x22] = chargingState(meta)
 	b[0x2A] = 0x01
 
 	if features&FeatureIMU != 0 {
@@ -132,11 +133,11 @@ func (s InputState) buildCommonReport(counter, motionTimestamp uint32, features 
 	return b
 }
 
-func (s InputState) buildProReport(counter uint8, features uint8) []byte {
+func (s InputState) buildProReport(counter uint8, features uint8, meta MetaState) []byte {
 	b := make([]byte, InputReportSize)
 	b[0] = ReportIDPro
 	b[1] = counter
-	b[2] = powerInfo(s)
+	b[2] = powerInfo(meta)
 
 	buttons := s.proButtonBytes()
 	copy(b[3:6], buttons[:])
@@ -247,23 +248,23 @@ func clampStick(v uint16) uint16 {
 	return v
 }
 
-func powerInfo(s InputState) uint8 {
-	level := s.BatteryLevel
+func powerInfo(meta MetaState) uint8 {
+	level := meta.BatteryLevel
 	if level > BatteryMax {
 		level = BatteryMax
 	}
 	out := (level & 0x0F) << 2
-	if s.ExternalPower {
+	if meta.ExternalPower {
 		out |= 0x01
 	}
-	if s.Charging {
+	if meta.Charging {
 		out |= 0x02
 	}
 	return out
 }
 
-func chargingState(s InputState) uint8 {
-	if s.Charging {
+func chargingState(meta MetaState) uint8 {
+	if meta.Charging {
 		return 0x34
 	}
 	return 0x20

--- a/device/ns2pro/inputstate.go
+++ b/device/ns2pro/inputstate.go
@@ -1,0 +1,270 @@
+package ns2pro
+
+import (
+	"encoding/binary"
+	"io"
+)
+
+// nolint
+// viiper:wire ns2pro c2s buttons:u32 lx:u16 ly:u16 rx:u16 ry:u16 accelX:i16 accelY:i16 accelZ:i16 gyroX:i16 gyroY:i16 gyroZ:i16 batteryLevel:u8 charging:bool externalPower:bool
+type InputState struct {
+	Buttons uint32
+
+	LX, LY uint16
+	RX, RY uint16
+
+	AccelX, AccelY, AccelZ int16
+	GyroX, GyroY, GyroZ    int16
+
+	BatteryLevel  uint8
+	Charging      bool
+	ExternalPower bool
+}
+
+func defaultInputState() *InputState {
+	return &InputState{
+		LX:            StickCenter,
+		LY:            StickCenter,
+		RX:            StickCenter,
+		RY:            StickCenter,
+		BatteryLevel:  BatteryMax,
+		ExternalPower: true,
+	}
+}
+
+func (s *InputState) MarshalBinary() ([]byte, error) {
+	b := make([]byte, InputWireSize)
+	binary.LittleEndian.PutUint32(b[0:4], s.Buttons)
+	binary.LittleEndian.PutUint16(b[4:6], s.LX)
+	binary.LittleEndian.PutUint16(b[6:8], s.LY)
+	binary.LittleEndian.PutUint16(b[8:10], s.RX)
+	binary.LittleEndian.PutUint16(b[10:12], s.RY)
+	binary.LittleEndian.PutUint16(b[12:14], uint16(s.AccelX))
+	binary.LittleEndian.PutUint16(b[14:16], uint16(s.AccelY))
+	binary.LittleEndian.PutUint16(b[16:18], uint16(s.AccelZ))
+	binary.LittleEndian.PutUint16(b[18:20], uint16(s.GyroX))
+	binary.LittleEndian.PutUint16(b[20:22], uint16(s.GyroY))
+	binary.LittleEndian.PutUint16(b[22:24], uint16(s.GyroZ))
+	b[24] = s.BatteryLevel
+	if s.Charging {
+		b[25] = 1
+	}
+	if s.ExternalPower {
+		b[26] = 1
+	}
+	return b, nil
+}
+
+func (s *InputState) UnmarshalBinary(data []byte) error {
+	if len(data) < InputWireSize {
+		return io.ErrUnexpectedEOF
+	}
+	s.Buttons = binary.LittleEndian.Uint32(data[0:4])
+	s.LX = binary.LittleEndian.Uint16(data[4:6])
+	s.LY = binary.LittleEndian.Uint16(data[6:8])
+	s.RX = binary.LittleEndian.Uint16(data[8:10])
+	s.RY = binary.LittleEndian.Uint16(data[10:12])
+	s.AccelX = int16(binary.LittleEndian.Uint16(data[12:14]))
+	s.AccelY = int16(binary.LittleEndian.Uint16(data[14:16]))
+	s.AccelZ = int16(binary.LittleEndian.Uint16(data[16:18]))
+	s.GyroX = int16(binary.LittleEndian.Uint16(data[18:20]))
+	s.GyroY = int16(binary.LittleEndian.Uint16(data[20:22]))
+	s.GyroZ = int16(binary.LittleEndian.Uint16(data[22:24]))
+	s.BatteryLevel = data[24]
+	s.Charging = data[25] != 0
+	s.ExternalPower = data[26] != 0
+	return nil
+}
+
+// nolint
+// viiper:wire ns2pro s2c leftRumble:u8*16 rightRumble:u8*16 flags:u8 playerLedMask:u8
+type OutputState struct {
+	LeftRumble    [16]byte
+	RightRumble   [16]byte
+	Flags         uint8
+	PlayerLedMask uint8
+}
+
+func (o *OutputState) MarshalBinary() ([]byte, error) {
+	b := make([]byte, OutputWireSize)
+	copy(b[0:16], o.LeftRumble[:])
+	copy(b[16:32], o.RightRumble[:])
+	b[32] = o.Flags
+	b[33] = o.PlayerLedMask
+	return b, nil
+}
+
+func (o *OutputState) UnmarshalBinary(data []byte) error {
+	if len(data) < OutputWireSize {
+		return io.ErrUnexpectedEOF
+	}
+	copy(o.LeftRumble[:], data[0:16])
+	copy(o.RightRumble[:], data[16:32])
+	o.Flags = data[32]
+	o.PlayerLedMask = data[33]
+	return nil
+}
+
+func (s InputState) buildCommonReport(counter, motionTimestamp uint32, features uint8, batteryVolts uint16) []byte {
+	b := make([]byte, InputReportSize)
+	b[0] = ReportIDCommon
+	binary.LittleEndian.PutUint32(b[1:5], counter)
+
+	buttons := s.commonButtonBytes()
+	copy(b[5:9], buttons[:])
+	packStick12(b[11:14], s.LX, s.LY)
+	packStick12(b[14:17], s.RX, s.RY)
+
+	binary.LittleEndian.PutUint16(b[0x20:0x22], batteryVolts)
+	b[0x22] = chargingState(s)
+	b[0x2A] = 0x01
+
+	if features&FeatureIMU != 0 {
+		binary.LittleEndian.PutUint32(b[0x2B:0x2F], motionTimestamp)
+		binary.LittleEndian.PutUint16(b[0x31:0x33], uint16(s.AccelX))
+		binary.LittleEndian.PutUint16(b[0x33:0x35], uint16(s.AccelY))
+		binary.LittleEndian.PutUint16(b[0x35:0x37], uint16(s.AccelZ))
+		binary.LittleEndian.PutUint16(b[0x37:0x39], uint16(s.GyroX))
+		binary.LittleEndian.PutUint16(b[0x39:0x3B], uint16(s.GyroY))
+		binary.LittleEndian.PutUint16(b[0x3B:0x3D], uint16(s.GyroZ))
+	}
+
+	return b
+}
+
+func (s InputState) buildProReport(counter uint8, features uint8) []byte {
+	b := make([]byte, InputReportSize)
+	b[0] = ReportIDPro
+	b[1] = counter
+	b[2] = powerInfo(s)
+
+	buttons := s.proButtonBytes()
+	copy(b[3:6], buttons[:])
+	packStick12(b[6:9], s.LX, s.LY)
+	packStick12(b[9:12], s.RX, s.RY)
+
+	if features&FeatureRumble != 0 {
+		b[12] = 0x38
+	} else {
+		b[12] = 0x30
+	}
+	b[13] = 0x00
+	b[14] = 0x00
+	b[15] = 0x00
+	return b
+}
+
+func (s InputState) commonButtonBytes() [4]byte {
+	var out [4]byte
+	encodeButtonMap(s.Buttons, commonButtonMap, out[:])
+	return out
+}
+
+func (s InputState) proButtonBytes() [3]byte {
+	var out [3]byte
+	encodeButtonMap(s.Buttons, proButtonMap, out[:])
+	return out
+}
+
+type buttonReportBit struct {
+	button uint32
+	index  int
+	mask   byte
+}
+
+func encodeButtonMap(buttons uint32, mapping []buttonReportBit, out []byte) {
+	for _, bit := range mapping {
+		if buttons&bit.button != 0 {
+			out[bit.index] |= bit.mask
+		}
+	}
+}
+
+var commonButtonMap = []buttonReportBit{
+	{ButtonY, 0, 0x01},
+	{ButtonX, 0, 0x02},
+	{ButtonB, 0, 0x04},
+	{ButtonA, 0, 0x08},
+	{ButtonR, 0, 0x40},
+	{ButtonZR, 0, 0x80},
+	{ButtonMinus, 1, 0x01},
+	{ButtonPlus, 1, 0x02},
+	{ButtonRightStick, 1, 0x04},
+	{ButtonLeftStick, 1, 0x08},
+	{ButtonHome, 1, 0x10},
+	{ButtonCapture, 1, 0x20},
+	{ButtonC, 1, 0x40},
+	{ButtonDown, 2, 0x01},
+	{ButtonUp, 2, 0x02},
+	{ButtonRight, 2, 0x04},
+	{ButtonLeft, 2, 0x08},
+	{ButtonL, 2, 0x40},
+	{ButtonZL, 2, 0x80},
+	{ButtonGR, 3, 0x01},
+	{ButtonGL, 3, 0x02},
+	{ButtonHeadset, 3, 0x10},
+}
+
+var proButtonMap = []buttonReportBit{
+	{ButtonB, 0, 0x01},
+	{ButtonA, 0, 0x02},
+	{ButtonY, 0, 0x04},
+	{ButtonX, 0, 0x08},
+	{ButtonR, 0, 0x10},
+	{ButtonZR, 0, 0x20},
+	{ButtonPlus, 0, 0x40},
+	{ButtonRightStick, 0, 0x80},
+	{ButtonDown, 1, 0x01},
+	{ButtonRight, 1, 0x02},
+	{ButtonLeft, 1, 0x04},
+	{ButtonUp, 1, 0x08},
+	{ButtonL, 1, 0x10},
+	{ButtonZL, 1, 0x20},
+	{ButtonMinus, 1, 0x40},
+	{ButtonLeftStick, 1, 0x80},
+	{ButtonHome, 2, 0x01},
+	{ButtonCapture, 2, 0x02},
+	{ButtonGR, 2, 0x04},
+	{ButtonGL, 2, 0x08},
+	{ButtonC, 2, 0x10},
+}
+
+func packStick12(out []byte, x, y uint16) {
+	if len(out) < 3 {
+		return
+	}
+	x = clampStick(x)
+	y = clampStick(y)
+	out[0] = byte(x)
+	out[1] = byte((x>>8)&0x0F) | byte((y&0x0F)<<4)
+	out[2] = byte(y >> 4)
+}
+
+func clampStick(v uint16) uint16 {
+	if v > StickMax {
+		return StickMax
+	}
+	return v
+}
+
+func powerInfo(s InputState) uint8 {
+	level := s.BatteryLevel
+	if level > BatteryMax {
+		level = BatteryMax
+	}
+	out := (level & 0x0F) << 2
+	if s.ExternalPower {
+		out |= 0x01
+	}
+	if s.Charging {
+		out |= 0x02
+	}
+	return out
+}
+
+func chargingState(s InputState) uint8 {
+	if s.Charging {
+		return 0x34
+	}
+	return 0x20
+}

--- a/device/ns2pro/ns2pro_test.go
+++ b/device/ns2pro/ns2pro_test.go
@@ -27,22 +27,26 @@ func TestBuildReport05(t *testing.T) {
 	require.NoError(t, err)
 
 	state := InputState{
-		Buttons:       ButtonA | ButtonB | ButtonR | ButtonZR | ButtonMinus | ButtonPlus | ButtonLeftStick | ButtonRightStick | ButtonHome | ButtonCapture | ButtonC | ButtonDown | ButtonRight | ButtonLeft | ButtonUp | ButtonL | ButtonZL | ButtonGR | ButtonGL | ButtonHeadset,
-		LX:            0x0123,
-		LY:            0x0456,
-		RX:            0x0789,
-		RY:            0x0ABC,
-		AccelX:        0x1122,
-		AccelY:        -0x1234,
-		AccelZ:        0x3344,
-		GyroX:         -0x0102,
-		GyroY:         0x5566,
-		GyroZ:         -0x0777,
+		Buttons: ButtonA | ButtonB | ButtonR | ButtonZR | ButtonMinus | ButtonPlus | ButtonLeftStick | ButtonRightStick | ButtonHome | ButtonCapture | ButtonC | ButtonDown | ButtonRight | ButtonLeft | ButtonUp | ButtonL | ButtonZL | ButtonGR | ButtonGL | ButtonHeadset,
+		LX:      0x0123,
+		LY:      0x0456,
+		RX:      0x0789,
+		RY:      0x0ABC,
+		AccelX:  0x1122,
+		AccelY:  -0x1234,
+		AccelZ:  0x3344,
+		GyroX:   -0x0102,
+		GyroY:   0x5566,
+		GyroZ:   -0x0777,
+	}
+	dev.UpdateInputState(state)
+	dev.SetMetaState(MetaState{
+		SerialNumber:  DefaultSerial,
 		BatteryLevel:  7,
 		Charging:      true,
 		ExternalPower: true,
-	}
-	dev.UpdateInputState(state)
+		BatteryVolts:  DefaultBatteryVolts,
+	})
 
 	dev.HandleTransfer(2, usbip.DirOut, featureCommand(0x02, FeatureButtons|FeatureSticks|FeatureIMU|FeatureRumble))
 	dev.HandleTransfer(2, usbip.DirOut, featureCommand(0x04, FeatureButtons|FeatureSticks|FeatureIMU|FeatureRumble))
@@ -60,7 +64,7 @@ func TestBuildReport05(t *testing.T) {
 	packStick12(rightStick[:], state.RX, state.RY)
 	assert.Equal(t, leftStick[:], report[11:14])
 	assert.Equal(t, rightStick[:], report[14:17])
-	assert.Equal(t, BatteryVolts, binary.LittleEndian.Uint16(report[0x20:0x22]))
+	assert.Equal(t, DefaultBatteryVolts, binary.LittleEndian.Uint16(report[0x20:0x22]))
 	assert.Equal(t, byte(0x34), report[0x22])
 	assert.Equal(t, byte(0x01), report[0x2A])
 	assert.Equal(t, uint32(4000), binary.LittleEndian.Uint32(report[0x2B:0x2F]))
@@ -92,7 +96,7 @@ func TestDescriptor(t *testing.T) {
 	assert.Equal(t, uint16(DefaultPID), desc.Device.IDProduct)
 	assert.Equal(t, uint16(0x0200), desc.Device.BcdDevice)
 	assert.Equal(t, "Switch 2 Pro Controller", desc.Strings[2])
-	assert.Equal(t, DefaultSerial, desc.Strings[3])
+	assert.Equal(t, DefaultSerialEnding, desc.Strings[3])
 	assert.Equal(t, "Nintendo Switch 2 Pro Controller", desc.Strings[4])
 	assert.Equal(t, "Nintendo Switch 2 Pro Controller", desc.Strings[5])
 	assert.Equal(t, "Pro Controller", desc.Strings[6])
@@ -122,20 +126,49 @@ func TestDescriptor(t *testing.T) {
 	assert.Equal(t, byte(EndpointBulkIn), bulkIface.Endpoints[1].BEndpointAddress)
 }
 
+func TestCreateDeviceDeduplicatesSerial(t *testing.T) {
+	serials = map[string]struct{}{}
+	t.Cleanup(func() {
+		serials = map[string]struct{}{}
+	})
+
+	h := &handler{}
+	dev1, err := h.CreateDevice(nil)
+	require.NoError(t, err)
+	dev2, err := h.CreateDevice(nil)
+	require.NoError(t, err)
+
+	ns1, ok := dev1.(*NS2Pro)
+	require.True(t, ok)
+	ns2, ok := dev2.(*NS2Pro)
+	require.True(t, ok)
+
+	serial1 := ns1.GetDescriptor().Strings[3]
+	serial2 := ns2.GetDescriptor().Strings[3]
+
+	assert.Equal(t, "00", serial1)
+	assert.Equal(t, "01", serial2)
+	assert.NotEqual(t, serial1, serial2)
+}
+
 func TestBuildReport09(t *testing.T) {
 	dev, err := New(nil)
 	require.NoError(t, err)
 
 	state := InputState{
-		Buttons:       ButtonB | ButtonA | ButtonX | ButtonZR | ButtonPlus | ButtonRightStick | ButtonDown | ButtonUp | ButtonL | ButtonZL | ButtonMinus | ButtonLeftStick | ButtonHome | ButtonCapture | ButtonGR | ButtonGL | ButtonC,
-		LX:            0x0001,
-		LY:            0x0002,
-		RX:            0x0FFE,
-		RY:            0x0FFF,
-		BatteryLevel:  5,
-		ExternalPower: true,
+		Buttons: ButtonB | ButtonA | ButtonX | ButtonZR | ButtonPlus | ButtonRightStick | ButtonDown | ButtonUp | ButtonL | ButtonZL | ButtonMinus | ButtonLeftStick | ButtonHome | ButtonCapture | ButtonGR | ButtonGL | ButtonC,
+		LX:      0x0001,
+		LY:      0x0002,
+		RX:      0x0FFE,
+		RY:      0x0FFF,
 	}
 	dev.UpdateInputState(state)
+	dev.SetMetaState(MetaState{
+		SerialNumber:  DefaultSerial,
+		BatteryLevel:  5,
+		ExternalPower: true,
+		BatteryVolts:  DefaultBatteryVolts,
+	})
 	dev.HandleTransfer(2, usbip.DirOut, selectReportCommand(ReportIDPro))
 	assert.NotEmpty(t, dev.HandleTransfer(2, usbip.DirIn, nil))
 
@@ -211,7 +244,13 @@ func TestSDLUSBInitializationSequence(t *testing.T) {
 		assert.NotEmpty(t, dev.HandleTransfer(2, usbip.DirIn, nil), "cmd %#x sub %#x", cmd[0], cmd[3])
 	}
 
-	dev.UpdateInputState(InputState{BatteryLevel: 9})
+	dev.SetMetaState(MetaState{
+		SerialNumber:  DefaultSerial,
+		BatteryLevel:  9,
+		ExternalPower: true,
+		BatteryVolts:  DefaultBatteryVolts,
+	})
+	dev.UpdateInputState(InputState{})
 	report := dev.HandleTransfer(1, usbip.DirIn, nil)
 	require.Len(t, report, InputReportSize)
 	assert.Equal(t, byte(ReportIDCommon), report[0])
@@ -348,7 +387,7 @@ func TestStreamInputAndRumble(t *testing.T) {
 
 	serialString, err := controlIn(imp.Conn, controlSetup(0x0303, 0, 64))
 	require.NoError(t, err)
-	assert.Equal(t, usb.EncodeStringDescriptor(DefaultSerial), serialString)
+	assert.Equal(t, usb.EncodeStringDescriptor(DefaultSerialEnding), serialString)
 
 	msOSString, err := controlIn(imp.Conn, controlSetup(0x03EE, 0, 18))
 	require.NoError(t, err)
@@ -374,17 +413,15 @@ func TestStreamInputAndRumble(t *testing.T) {
 	require.NoError(t, usbipClient.Submit(imp.Conn, usbip.DirOut, 2, selectReportCommand(ReportIDPro), nil))
 
 	state := InputState{
-		Buttons:       ButtonA | ButtonHome | ButtonRight,
-		LX:            0x0123,
-		LY:            0x0456,
-		RX:            0x0789,
-		RY:            0x0ABC,
-		BatteryLevel:  6,
-		ExternalPower: true,
+		Buttons: ButtonA | ButtonHome | ButtonRight,
+		LX:      0x0123,
+		LY:      0x0456,
+		RX:      0x0789,
+		RY:      0x0ABC,
 	}
 	require.NoError(t, stream.WriteBinary(&state))
 
-	expected := state.buildProReport(0, FeatureButtons|FeatureSticks)
+	expected := state.buildProReport(0, FeatureButtons|FeatureSticks, *defaultMetaState())
 	got := pollInputIgnoringCounter(t, usbipClient, imp.Conn, expected, 750*time.Millisecond)
 	require.Len(t, got, InputReportSize)
 	got[1] = 0
@@ -442,7 +479,7 @@ func utf16leToString(b []byte) string {
 	return string(utf16.Decode(units))
 }
 
-func controlSetup(wValue, wIndex, wLength uint16) [8]byte {
+func controlSetup(wValue, wIndex, wLength uint16) [8]byte { // nolint:unparam
 	var setup [8]byte
 	setup[0] = 0x80 // bmRequestType
 	setup[1] = 0x06 // bRequest

--- a/device/ns2pro/ns2pro_test.go
+++ b/device/ns2pro/ns2pro_test.go
@@ -1,0 +1,508 @@
+package ns2pro
+
+import (
+	"context"
+	"encoding/binary"
+	"encoding/hex"
+	"fmt"
+	"io"
+	"net"
+	"testing"
+	"time"
+	"unicode/utf16"
+
+	viiperTesting "github.com/Alia5/VIIPER/_testing"
+	"github.com/Alia5/VIIPER/internal/server/api"
+	apihandler "github.com/Alia5/VIIPER/internal/server/api/handler"
+	"github.com/Alia5/VIIPER/usb"
+	"github.com/Alia5/VIIPER/usbip"
+	"github.com/Alia5/VIIPER/viiperclient"
+	"github.com/Alia5/VIIPER/virtualbus"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestBuildReport05(t *testing.T) {
+	dev, err := New(nil)
+	require.NoError(t, err)
+
+	state := InputState{
+		Buttons:       ButtonA | ButtonB | ButtonR | ButtonZR | ButtonMinus | ButtonPlus | ButtonLeftStick | ButtonRightStick | ButtonHome | ButtonCapture | ButtonC | ButtonDown | ButtonRight | ButtonLeft | ButtonUp | ButtonL | ButtonZL | ButtonGR | ButtonGL | ButtonHeadset,
+		LX:            0x0123,
+		LY:            0x0456,
+		RX:            0x0789,
+		RY:            0x0ABC,
+		AccelX:        0x1122,
+		AccelY:        -0x1234,
+		AccelZ:        0x3344,
+		GyroX:         -0x0102,
+		GyroY:         0x5566,
+		GyroZ:         -0x0777,
+		BatteryLevel:  7,
+		Charging:      true,
+		ExternalPower: true,
+	}
+	dev.UpdateInputState(state)
+
+	dev.HandleTransfer(2, usbip.DirOut, featureCommand(0x02, FeatureButtons|FeatureSticks|FeatureIMU|FeatureRumble))
+	dev.HandleTransfer(2, usbip.DirOut, featureCommand(0x04, FeatureButtons|FeatureSticks|FeatureIMU|FeatureRumble))
+	dev.HandleTransfer(2, usbip.DirOut, selectReportCommand(ReportIDCommon))
+
+	report := dev.HandleTransfer(1, usbip.DirIn, nil)
+	require.Len(t, report, InputReportSize)
+	assert.Equal(t, byte(ReportIDCommon), report[0])
+	assert.Equal(t, uint32(1), binary.LittleEndian.Uint32(report[1:5]))
+	assert.Equal(t, []byte{0xCC, 0x7F, 0xCF, 0x13}, report[5:9])
+
+	var leftStick [3]byte
+	var rightStick [3]byte
+	packStick12(leftStick[:], state.LX, state.LY)
+	packStick12(rightStick[:], state.RX, state.RY)
+	assert.Equal(t, leftStick[:], report[11:14])
+	assert.Equal(t, rightStick[:], report[14:17])
+	assert.Equal(t, BatteryVolts, binary.LittleEndian.Uint16(report[0x20:0x22]))
+	assert.Equal(t, byte(0x34), report[0x22])
+	assert.Equal(t, byte(0x01), report[0x2A])
+	assert.Equal(t, uint32(4000), binary.LittleEndian.Uint32(report[0x2B:0x2F]))
+	assert.Equal(t, uint16(state.AccelX), binary.LittleEndian.Uint16(report[0x31:0x33]))
+	assert.Equal(t, uint16(state.AccelY), binary.LittleEndian.Uint16(report[0x33:0x35]))
+	assert.Equal(t, uint16(state.AccelZ), binary.LittleEndian.Uint16(report[0x35:0x37]))
+	assert.Equal(t, uint16(state.GyroX), binary.LittleEndian.Uint16(report[0x37:0x39]))
+	assert.Equal(t, uint16(state.GyroY), binary.LittleEndian.Uint16(report[0x39:0x3B]))
+	assert.Equal(t, uint16(state.GyroZ), binary.LittleEndian.Uint16(report[0x3B:0x3D]))
+
+	next := dev.HandleTransfer(1, usbip.DirIn, nil)
+	require.Len(t, next, InputReportSize)
+	assert.Equal(t, uint32(2), binary.LittleEndian.Uint32(next[1:5]))
+	assert.Equal(t, uint32(8000), binary.LittleEndian.Uint32(next[0x2B:0x2F]))
+}
+
+func TestHIDReportDescriptorMatchesCapture(t *testing.T) {
+	got, err := reportDescriptor.Bytes()
+	require.NoError(t, err)
+	assert.Equal(t,
+		mustHexBytes(t, "05010905a101850505ff0901150026ff00953f750881028509090195028102050919012915250195157501810295017503810305010901a100093009310933093526ff0f9504750c8102c005ff090226ff0095347508810285020901953f9102c0"),
+		[]byte(got),
+	)
+}
+
+func TestDescriptor(t *testing.T) {
+	desc := MakeDescriptor()
+	assert.Equal(t, uint16(DefaultVID), desc.Device.IDVendor)
+	assert.Equal(t, uint16(DefaultPID), desc.Device.IDProduct)
+	assert.Equal(t, uint16(0x0200), desc.Device.BcdDevice)
+	assert.Equal(t, "Switch 2 Pro Controller", desc.Strings[2])
+	assert.Equal(t, DefaultSerial, desc.Strings[3])
+	assert.Equal(t, "Nintendo Switch 2 Pro Controller", desc.Strings[4])
+	assert.Equal(t, "Nintendo Switch 2 Pro Controller", desc.Strings[5])
+	assert.Equal(t, "Pro Controller", desc.Strings[6])
+	assert.Equal(t, byte(0x04), desc.Configuration.IConfiguration)
+	assert.Equal(t, byte(0xC0), desc.Configuration.BMAttributes)
+	assert.Equal(t, byte(0xFA), desc.Configuration.BMaxPower)
+	require.NotNil(t, desc.MicrosoftOS10)
+	assert.Equal(t, byte(microsoftOS10VendorCode), desc.MicrosoftOS10.VendorCode)
+	assert.Equal(t, uint8(2), desc.NumInterfaces())
+	require.Empty(t, desc.Associations)
+	require.Len(t, desc.Interfaces, 2)
+
+	hidIface := desc.Interfaces[0]
+	assert.Equal(t, byte(0x03), hidIface.Descriptor.BInterfaceClass)
+	require.NotNil(t, hidIface.HID)
+	require.Len(t, hidIface.Endpoints, 2)
+	assert.Equal(t, byte(EndpointHIDIn), hidIface.Endpoints[0].BEndpointAddress)
+	assert.Equal(t, byte(EndpointHIDOut), hidIface.Endpoints[1].BEndpointAddress)
+	report, err := hidIface.HID.ReportBytes()
+	require.NoError(t, err)
+	assert.Len(t, report, 97)
+
+	bulkIface := desc.Interfaces[1]
+	assert.Equal(t, byte(0xFF), bulkIface.Descriptor.BInterfaceClass)
+	require.Len(t, bulkIface.Endpoints, 2)
+	assert.Equal(t, byte(EndpointBulkOut), bulkIface.Endpoints[0].BEndpointAddress)
+	assert.Equal(t, byte(EndpointBulkIn), bulkIface.Endpoints[1].BEndpointAddress)
+}
+
+func TestBuildReport09(t *testing.T) {
+	dev, err := New(nil)
+	require.NoError(t, err)
+
+	state := InputState{
+		Buttons:       ButtonB | ButtonA | ButtonX | ButtonZR | ButtonPlus | ButtonRightStick | ButtonDown | ButtonUp | ButtonL | ButtonZL | ButtonMinus | ButtonLeftStick | ButtonHome | ButtonCapture | ButtonGR | ButtonGL | ButtonC,
+		LX:            0x0001,
+		LY:            0x0002,
+		RX:            0x0FFE,
+		RY:            0x0FFF,
+		BatteryLevel:  5,
+		ExternalPower: true,
+	}
+	dev.UpdateInputState(state)
+	dev.HandleTransfer(2, usbip.DirOut, selectReportCommand(ReportIDPro))
+	assert.NotEmpty(t, dev.HandleTransfer(2, usbip.DirIn, nil))
+
+	report := dev.HandleTransfer(1, usbip.DirIn, nil)
+	require.Len(t, report, InputReportSize)
+	assert.Equal(t, byte(ReportIDPro), report[0])
+	assert.Equal(t, byte(1), report[1])
+	assert.Equal(t, byte(0x15), report[2])
+	assert.Equal(t, []byte{0xEB, 0xF9, 0x1F}, report[3:6])
+	assert.Equal(t, byte(0x30), report[12])
+
+	var leftStick [3]byte
+	var rightStick [3]byte
+	packStick12(leftStick[:], state.LX, state.LY)
+	packStick12(rightStick[:], state.RX, state.RY)
+	assert.Equal(t, leftStick[:], report[6:9])
+	assert.Equal(t, rightStick[:], report[9:12])
+}
+
+func TestBulkCommands(t *testing.T) {
+	dev, err := New(nil)
+	require.NoError(t, err)
+
+	dev.HandleTransfer(2, usbip.DirOut, featureCommand(0x02, FeatureButtons|FeatureSticks|FeatureIMU|FeatureRumble))
+	assert.NotEmpty(t, dev.HandleTransfer(2, usbip.DirIn, nil))
+	dev.HandleTransfer(2, usbip.DirOut, featureCommand(0x04, FeatureButtons|FeatureSticks|FeatureIMU|FeatureRumble))
+	assert.NotEmpty(t, dev.HandleTransfer(2, usbip.DirIn, nil))
+
+	dev.HandleTransfer(2, usbip.DirOut, selectReportCommand(ReportIDCommon))
+	assert.NotEmpty(t, dev.HandleTransfer(2, usbip.DirIn, nil))
+	report := dev.HandleTransfer(1, usbip.DirIn, nil)
+	require.Len(t, report, InputReportSize)
+	assert.Equal(t, byte(ReportIDCommon), report[0])
+
+	dev.HandleTransfer(2, usbip.DirOut, flashReadCommand(0x13000))
+	resp := dev.HandleTransfer(2, usbip.DirIn, nil)
+	require.Len(t, resp, 0x50)
+	assert.Equal(t, []byte{0x02, 0x01, 0x01, 0x01}, resp[0:4])
+	assert.Equal(t, byte(0x40), resp[8])
+	assert.Equal(t, uint32(0x13000), binary.LittleEndian.Uint32(resp[12:16]))
+	flash := resp[16:]
+	require.Len(t, flash, 64)
+	assert.Equal(t, "VIIPER-NS2PRO-00", string(flash[2:18]))
+}
+
+func TestSDLUSBInitializationSequence(t *testing.T) {
+	dev, err := New(nil)
+	require.NoError(t, err)
+
+	for _, address := range []uint32{0x13000, 0x13040, 0x13080, 0x130C0, 0x13100, 0x1FC040, 0x1FC080} {
+		dev.HandleTransfer(2, usbip.DirOut, flashReadCommand(address))
+		resp := dev.HandleTransfer(2, usbip.DirIn, nil)
+		require.Len(t, resp, 0x50, "flash block %#x", address)
+		assert.Equal(t, []byte{0x02, 0x01, 0x01, 0x01}, resp[0:4])
+		assert.Equal(t, byte(0x40), resp[8])
+		assert.Equal(t, address, binary.LittleEndian.Uint32(resp[12:16]))
+	}
+
+	initSequence := [][]byte{
+		{0x07, 0x91, 0x00, 0x01, 0x00, 0x00, 0x00, 0x00},
+		{0x0C, 0x91, 0x00, 0x02, 0x00, 0x04, 0x00, 0x00, 0x27, 0x00, 0x00, 0x00},
+		{0x11, 0x91, 0x00, 0x01, 0x00, 0x00, 0x00, 0x00},
+		{0x0A, 0x91, 0x00, 0x08, 0x00, 0x14, 0x00, 0x00, 0x01, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0x35, 0x00, 0x46, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00},
+		{0x0C, 0x91, 0x00, 0x04, 0x00, 0x04, 0x00, 0x00, 0x27, 0x00, 0x00, 0x00},
+		{0x01, 0x91, 0x00, 0x0C, 0x00, 0x00, 0x00, 0x00},
+		{0x01, 0x91, 0x00, 0x01, 0x00, 0x00, 0x00, 0x00},
+		{0x08, 0x91, 0x00, 0x02, 0x00, 0x04, 0x00, 0x00, 0x01, 0x00, 0x00, 0x00},
+		{0x03, 0x91, 0x00, 0x0A, 0x00, 0x04, 0x00, 0x00, 0x05, 0x00, 0x00, 0x00},
+		{0x03, 0x91, 0x00, 0x0D, 0x00, 0x08, 0x00, 0x00, 0x01, 0x00, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF},
+	}
+	for _, cmd := range initSequence {
+		dev.HandleTransfer(2, usbip.DirOut, cmd)
+		assert.NotEmpty(t, dev.HandleTransfer(2, usbip.DirIn, nil), "cmd %#x sub %#x", cmd[0], cmd[3])
+	}
+
+	dev.UpdateInputState(InputState{BatteryLevel: 9})
+	report := dev.HandleTransfer(1, usbip.DirIn, nil)
+	require.Len(t, report, InputReportSize)
+	assert.Equal(t, byte(ReportIDCommon), report[0])
+	assert.Equal(t, uint32(1), binary.LittleEndian.Uint32(report[1:5]))
+	assert.Equal(t, uint32(4000), binary.LittleEndian.Uint32(report[0x2B:0x2F]))
+}
+
+func TestRumbleOutput(t *testing.T) {
+	dev, err := New(nil)
+	require.NoError(t, err)
+
+	var got OutputState
+	called := false
+	dev.SetOutputCallback(func(out OutputState) {
+		got = out
+		called = true
+	})
+
+	packet := make([]byte, OutputReportSize)
+	packet[0] = ReportIDOutput
+	for i := 0; i < 16; i++ {
+		packet[1+i] = byte(i)
+		packet[17+i] = byte(0x80 + i)
+	}
+	dev.HandleTransfer(1, usbip.DirOut, packet)
+
+	require.True(t, called)
+	assert.Equal(t, byte(OutputFlagRumble), got.Flags)
+	for i := 0; i < 16; i++ {
+		assert.Equal(t, byte(i), got.LeftRumble[i])
+		assert.Equal(t, byte(0x80+i), got.RightRumble[i])
+	}
+
+	called = false
+	payload := make([]byte, OutputRumbleSize)
+	for i := 0; i < 16; i++ {
+		payload[i] = byte(0x40 + i)
+		payload[16+i] = byte(0xC0 + i)
+	}
+	_, handled := dev.HandleControl(0x21, 0x09, 0x0202, 0, 0, payload)
+	require.True(t, handled)
+	require.True(t, called)
+	assert.Equal(t, byte(OutputFlagRumble), got.Flags)
+	assert.Equal(t, byte(0x40), got.LeftRumble[0])
+	assert.Equal(t, byte(0xC0), got.RightRumble[0])
+}
+
+func TestPlayerLEDOutput(t *testing.T) {
+	dev, err := New(nil)
+	require.NoError(t, err)
+
+	var got OutputState
+	called := false
+	dev.SetOutputCallback(func(out OutputState) {
+		got = out
+		called = true
+	})
+
+	dev.HandleTransfer(2, usbip.DirOut, []byte{0x09, 0x91, 0x12, 0x07, 0x00, 0x08, 0x00, 0x00, 0x06, 0x00, 0x00, 0x00})
+	resp := dev.HandleTransfer(2, usbip.DirIn, nil)
+
+	require.True(t, called)
+	assert.Equal(t, byte(OutputFlagLED), got.Flags)
+	assert.Equal(t, byte(0x06), got.PlayerLedMask)
+	assert.Equal(t, []byte{0x09, 0x01, 0x12, 0x07}, resp[:4])
+}
+
+func TestMicrosoftOS10WinUSBDescriptor(t *testing.T) {
+	desc := MakeDescriptor()
+	require.NotNil(t, desc.MicrosoftOS10)
+
+	resp, handled := desc.MicrosoftOS10.ControlResponse(0, 0x0004)
+	require.True(t, handled)
+	require.Len(t, resp, 40)
+	assert.Equal(t, uint32(40), binary.LittleEndian.Uint32(resp[0:4]))
+	assert.Equal(t, uint16(0x0100), binary.LittleEndian.Uint16(resp[4:6]))
+	assert.Equal(t, uint16(0x0004), binary.LittleEndian.Uint16(resp[6:8]))
+	assert.Equal(t, byte(0x01), resp[8])
+	assert.Equal(t, byte(0x01), resp[16])
+	assert.Equal(t, []byte("WINUSB\x00\x00"), resp[18:26])
+}
+
+func TestMicrosoftOS10ExtendedPropertiesDescriptor(t *testing.T) {
+	desc := MakeDescriptor()
+	require.NotNil(t, desc.MicrosoftOS10)
+
+	resp, handled := desc.MicrosoftOS10.ControlResponse(0, 0x0005)
+	require.True(t, handled)
+	require.Len(t, resp, 142)
+	assert.Equal(t, uint32(142), binary.LittleEndian.Uint32(resp[0:4]))
+	assert.Equal(t, uint16(0x0100), binary.LittleEndian.Uint16(resp[4:6]))
+	assert.Equal(t, uint16(0x0005), binary.LittleEndian.Uint16(resp[6:8]))
+	assert.Equal(t, uint16(1), binary.LittleEndian.Uint16(resp[8:10]))
+	assert.Equal(t, uint32(132), binary.LittleEndian.Uint32(resp[10:14]))
+	assert.Equal(t, uint32(1), binary.LittleEndian.Uint32(resp[14:18]))
+	assert.Equal(t, uint16(40), binary.LittleEndian.Uint16(resp[18:20]))
+	assert.Equal(t, uint32(78), binary.LittleEndian.Uint32(resp[60:64]))
+	assert.Contains(t, utf16leToString(resp[20:60]), "DeviceInterfaceGUID")
+	assert.Contains(t, utf16leToString(resp[64:]), microsoftOS10DeviceInterfaceGUID)
+}
+
+func TestStreamInputAndRumble(t *testing.T) {
+	s := viiperTesting.NewTestServer(t)
+	defer s.UsbServer.Close()
+	defer s.ApiServer.Close()
+
+	r := s.ApiServer.Router()
+	r.Register("bus/{id}/add", apihandler.BusDeviceAdd(s.UsbServer, s.ApiServer))
+	r.RegisterStream("bus/{busId}/{deviceid}", api.DeviceStreamHandler(s.UsbServer))
+
+	require.NoError(t, s.ApiServer.Start())
+
+	b, err := virtualbus.NewWithBusID(1)
+	require.NoError(t, err)
+	defer b.Close()
+	require.NoError(t, s.UsbServer.AddBus(b))
+
+	client := viiperclient.New(s.ApiServer.Addr())
+	stream, _, err := client.AddDeviceAndConnect(context.Background(), b.BusID(), "ns2pro", nil)
+	require.NoError(t, err)
+	defer stream.Close()
+
+	usbipClient := viiperTesting.NewUsbIpClient(t, s.UsbServer.Addr())
+	devs, err := usbipClient.ListDevices()
+	require.NoError(t, err)
+	require.Len(t, devs, 1)
+	imp, err := usbipClient.AttachDevice(devs[0].BusID)
+	require.NoError(t, err)
+	defer imp.Conn.Close()
+
+	productString, err := controlIn(imp.Conn, controlSetup(0x0302, 0, 64))
+	require.NoError(t, err)
+	assert.Equal(t, usb.EncodeStringDescriptor("Switch 2 Pro Controller"), productString)
+
+	serialString, err := controlIn(imp.Conn, controlSetup(0x0303, 0, 64))
+	require.NoError(t, err)
+	assert.Equal(t, usb.EncodeStringDescriptor(DefaultSerial), serialString)
+
+	msOSString, err := controlIn(imp.Conn, controlSetup(0x03EE, 0, 18))
+	require.NoError(t, err)
+	assert.Equal(t, []byte{
+		0x12, 0x03,
+		'M', 0x00,
+		'S', 0x00,
+		'F', 0x00,
+		'T', 0x00,
+		'1', 0x00,
+		'0', 0x00,
+		'0', 0x00,
+		microsoftOS10VendorCode, 0x00,
+	}, msOSString)
+
+	config, err := controlIn(imp.Conn, controlSetup(0x0200, 0, 512))
+	require.NoError(t, err)
+	require.Len(t, config, 64)
+	assert.Equal(t, []byte{0x09, 0x02, 0x40, 0x00, 0x02, 0x01, 0x04, 0xC0, 0xFA}, config[:9])
+	assert.Equal(t, []byte{0x09, 0x04, 0x00, 0x00, 0x02, 0x03, 0x00, 0x00, 0x05}, config[9:18])
+	assert.Equal(t, []byte{0x09, 0x04, 0x01, 0x00, 0x02, 0xFF, 0x00, 0x00, 0x06}, config[41:50])
+
+	require.NoError(t, usbipClient.Submit(imp.Conn, usbip.DirOut, 2, selectReportCommand(ReportIDPro), nil))
+
+	state := InputState{
+		Buttons:       ButtonA | ButtonHome | ButtonRight,
+		LX:            0x0123,
+		LY:            0x0456,
+		RX:            0x0789,
+		RY:            0x0ABC,
+		BatteryLevel:  6,
+		ExternalPower: true,
+	}
+	require.NoError(t, stream.WriteBinary(&state))
+
+	expected := state.buildProReport(0, FeatureButtons|FeatureSticks)
+	got := pollInputIgnoringCounter(t, usbipClient, imp.Conn, expected, 750*time.Millisecond)
+	require.Len(t, got, InputReportSize)
+	got[1] = 0
+	assert.Equal(t, expected, got)
+
+	rumble := make([]byte, OutputReportSize)
+	rumble[0] = ReportIDOutput
+	for i := 0; i < 16; i++ {
+		rumble[1+i] = byte(0x10 + i)
+		rumble[17+i] = byte(0x90 + i)
+	}
+	require.NoError(t, usbipClient.Submit(imp.Conn, usbip.DirOut, 1, rumble, nil))
+
+	var outBuf [OutputWireSize]byte
+	_ = stream.SetReadDeadline(time.Now().Add(750 * time.Millisecond))
+	_, err = io.ReadFull(stream, outBuf[:])
+	require.NoError(t, err)
+	var out OutputState
+	require.NoError(t, out.UnmarshalBinary(outBuf[:]))
+	assert.Equal(t, byte(OutputFlagRumble), out.Flags)
+	assert.Equal(t, byte(0x10), out.LeftRumble[0])
+	assert.Equal(t, byte(0x90), out.RightRumble[0])
+}
+
+func featureCommand(sub, flags uint8) []byte {
+	return []byte{0x0C, 0x91, 0x00, sub, 0x00, 0x04, 0x00, 0x00, flags, 0x00, 0x00, 0x00}
+}
+
+func selectReportCommand(reportID uint8) []byte {
+	return []byte{0x03, 0x91, 0x00, 0x0A, 0x00, 0x04, 0x00, 0x00, reportID, 0x00, 0x00, 0x00}
+}
+
+func flashReadCommand(address uint32) []byte {
+	cmd := []byte{0x02, 0x91, 0x01, 0x01, 0x00, 0x08, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00}
+	binary.LittleEndian.PutUint32(cmd[12:16], address)
+	return cmd
+}
+
+func mustHexBytes(t *testing.T, s string) []byte {
+	t.Helper()
+	out, err := hex.DecodeString(s)
+	require.NoError(t, err)
+	return out
+}
+
+func utf16leToString(b []byte) string {
+	units := make([]uint16, 0, len(b)/2)
+	for i := 0; i+1 < len(b); i += 2 {
+		u := binary.LittleEndian.Uint16(b[i : i+2])
+		if u == 0 {
+			break
+		}
+		units = append(units, u)
+	}
+	return string(utf16.Decode(units))
+}
+
+func controlSetup(wValue, wIndex, wLength uint16) [8]byte {
+	var setup [8]byte
+	setup[0] = 0x80 // bmRequestType
+	setup[1] = 0x06 // bRequest
+	binary.LittleEndian.PutUint16(setup[2:4], wValue)
+	binary.LittleEndian.PutUint16(setup[4:6], wIndex)
+	binary.LittleEndian.PutUint16(setup[6:8], wLength)
+	return setup
+}
+
+func controlIn(conn net.Conn, setup [8]byte) ([]byte, error) {
+	cmd := usbip.CmdSubmit{
+		Basic:             usbip.HeaderBasic{Command: usbip.CmdSubmitCode, Seqnum: 0xC001, Devid: 0, Dir: usbip.DirIn, Ep: 0},
+		TransferBufferLen: uint32(binary.LittleEndian.Uint16(setup[6:8])),
+		Setup:             setup,
+	}
+	_ = conn.SetDeadline(time.Now().Add(750 * time.Millisecond))
+	defer conn.SetDeadline(time.Time{})
+	if err := cmd.Write(conn); err != nil {
+		return nil, err
+	}
+
+	var retHdr [48]byte
+	if err := usbip.ReadExactly(conn, retHdr[:]); err != nil {
+		return nil, err
+	}
+	if gotCmd := binary.BigEndian.Uint32(retHdr[0:4]); gotCmd != usbip.RetSubmitCode {
+		return nil, fmt.Errorf("unexpected ret cmd %x", gotCmd)
+	}
+	if status := int32(binary.BigEndian.Uint32(retHdr[20:24])); status != 0 {
+		return nil, fmt.Errorf("ret status %d", status)
+	}
+	actual := binary.BigEndian.Uint32(retHdr[24:28])
+	data := make([]byte, int(actual))
+	if actual > 0 {
+		if err := usbip.ReadExactly(conn, data); err != nil {
+			return nil, err
+		}
+	}
+	return data, nil
+}
+
+func pollInputIgnoringCounter(t *testing.T, client *viiperTesting.TestUsbIpClient, conn net.Conn, want []byte, timeout time.Duration) []byte {
+	t.Helper()
+
+	deadline := time.Now().Add(timeout)
+	for {
+		got, err := client.ReadInputReport(conn)
+		require.NoError(t, err)
+		if len(got) == len(want) {
+			g := append([]byte(nil), got...)
+			w := append([]byte(nil), want...)
+			g[1] = 0
+			w[1] = 0
+			if assert.ObjectsAreEqual(w, g) {
+				return got
+			}
+		}
+		if time.Now().After(deadline) {
+			return got
+		}
+		time.Sleep(1 * time.Millisecond)
+	}
+}

--- a/docs/clients/go.md
+++ b/docs/clients/go.md
@@ -203,6 +203,7 @@ Full working examples are available in the repository:
 - **Virtual Mouse**: `examples/go/virtual_mouse/main.go`
 - **Virtual Keyboard**: `examples/go/virtual_keyboard/main.go`
 - **Virtual Xbox360 Controller**: `examples/go/virtual_x360_pad/main.go`
+- **Virtual Switch 2 Pro Controller**: `examples/go/virtual_ns2pro/main.go`
 - More examples are always being added!
 
 ## See Also

--- a/docs/devices/ns2pro.md
+++ b/docs/devices/ns2pro.md
@@ -1,0 +1,63 @@
+# Switch 2 Pro Controller
+
+The `ns2pro` virtual gamepad emulates a Nintendo Switch 2 Pro Controller over USB.
+It exposes the Switch 2 HID reports used by SDL, including buttons, sticks,
+gyro/accelerometer data, and HD rumble output.
+
+=== "TCP API"
+
+    Use `ns2pro` as the device type when adding a device via the API or client libraries.
+
+    ## Client Library Support
+
+    The Go client can use the built-in types from `/device/ns2pro`.
+    Generated client libraries will pick up the `viiper:wire` tags from this package
+    the next time codegen is run.
+
+    ## Raw Streaming Protocol
+
+    The device stream is a bidirectional raw TCP connection with fixed-size packets.
+
+    ### Input State
+
+    - 27-byte packets, little-endian layout:
+        - Buttons: `uint32` bitfield
+        - Sticks: `LX`, `LY`, `RX`, `RY` as raw `uint16` values, clamped to `0..4095`
+        - Accelerometer: `AccelX`, `AccelY`, `AccelZ` as raw `int16` report values
+        - Gyroscope: `GyroX`, `GyroY`, `GyroZ` as raw `int16` report values
+        - Battery: `BatteryLevel` (`0..9`), `Charging`, `ExternalPower`
+
+    ### Feedback
+
+    - 34-byte packets:
+        - `LeftRumble`: 16 bytes copied from HID output report `0x02`
+        - `RightRumble`: 16 bytes copied from HID output report `0x02`
+        - `Flags`: bit 0 = rumble update, bit 1 = player LED update
+        - `PlayerLedMask`: SDL/Steam player LED mask from bulk command `0x09/0x07`
+
+    ## Notes
+
+    VIIPER implements the HID and vendor bulk command paths needed by SDL's Switch 2
+    driver. The USB identity mirrors a wired Switch 2 Pro Controller closely enough
+    for host-side drivers to find the HID interface and vendor bulk interface:
+    product string `Switch 2 Pro Controller`, serial `00`, `bcdDevice=0x0200`,
+    HID plus vendor bulk interfaces, and Microsoft OS 1.0 compatible ID and
+    extended properties descriptors that bind the vendor bulk interface to WinUSB
+    on Windows.
+
+    NFC, Bluetooth GATT, and headset audio streaming are not emulated.
+
+    Gyro and accelerometer values are raw report values. Clients that need physical
+    units should convert them according to their target host or driver conventions.
+
+    ## Button Constants
+
+    | Button | Constant |
+    | --- | --- |
+    | B / A / Y / X | `ButtonB`, `ButtonA`, `ButtonY`, `ButtonX` |
+    | L / R / ZL / ZR | `ButtonL`, `ButtonR`, `ButtonZL`, `ButtonZR` |
+    | Plus / Minus | `ButtonPlus`, `ButtonMinus` |
+    | Stick clicks | `ButtonLeftStick`, `ButtonRightStick` |
+    | D-pad | `ButtonUp`, `ButtonDown`, `ButtonLeft`, `ButtonRight` |
+    | System buttons | `ButtonHome`, `ButtonCapture`, `ButtonC` |
+    | Grip buttons | `ButtonGL`, `ButtonGR` |

--- a/examples/go/virtual_ns2pro/main.go
+++ b/examples/go/virtual_ns2pro/main.go
@@ -107,19 +107,17 @@ func main() {
 			angle := float64(frame) * 0.045
 
 			state := ns2pro.InputState{
-				Buttons:       demoButtons(frame),
-				LX:            stickAxis(math.Cos(angle)),
-				LY:            stickAxis(math.Sin(angle)),
-				RX:            ns2pro.StickCenter,
-				RY:            ns2pro.StickCenter,
-				AccelX:        int16(800 * math.Sin(angle*0.5)),
-				AccelY:        int16(800 * math.Cos(angle*0.5)),
-				AccelZ:        -4096,
-				GyroX:         int16(500 * math.Sin(angle)),
-				GyroY:         int16(500 * math.Cos(angle)),
-				GyroZ:         int16(250 * math.Sin(angle*0.33)),
-				BatteryLevel:  ns2pro.BatteryMax,
-				ExternalPower: true,
+				Buttons: demoButtons(frame),
+				LX:      stickAxis(math.Cos(angle)),
+				LY:      stickAxis(math.Sin(angle)),
+				RX:      ns2pro.StickCenter,
+				RY:      ns2pro.StickCenter,
+				AccelX:  int16(800 * math.Sin(angle*0.5)),
+				AccelY:  int16(800 * math.Cos(angle*0.5)),
+				AccelZ:  -4096,
+				GyroX:   int16(500 * math.Sin(angle)),
+				GyroY:   int16(500 * math.Cos(angle)),
+				GyroZ:   int16(250 * math.Sin(angle*0.33)),
 			}
 
 			if err := stream.WriteBinary(&state); err != nil {

--- a/examples/go/virtual_ns2pro/main.go
+++ b/examples/go/virtual_ns2pro/main.go
@@ -1,0 +1,194 @@
+package main
+
+import (
+	"bufio"
+	"context"
+	"encoding"
+	"fmt"
+	"io"
+	"math"
+	"os"
+	"os/signal"
+	"syscall"
+	"time"
+
+	"github.com/Alia5/VIIPER/device/ns2pro"
+	"github.com/Alia5/VIIPER/viiperclient"
+)
+
+func main() {
+	if len(os.Args) != 2 {
+		fmt.Println("Usage: virtual_ns2pro <api_addr>")
+		fmt.Println("Example: virtual_ns2pro localhost:3242")
+		os.Exit(1)
+	}
+
+	addr := os.Args[1]
+	ctx := context.Background()
+	api := viiperclient.New(addr)
+
+	busID, createdBus, err := findOrCreateBus(ctx, api)
+	if err != nil {
+		fmt.Printf("Bus setup error: %v\n", err)
+		os.Exit(1)
+	}
+
+	stream, addResp, err := api.AddDeviceAndConnect(ctx, busID, "ns2pro", nil)
+	if err != nil {
+		fmt.Printf("AddDeviceAndConnect error: %v\n", err)
+		if createdBus {
+			_, _ = api.BusRemoveCtx(ctx, busID)
+		}
+		os.Exit(1)
+	}
+	defer stream.Close() // nolint
+
+	fmt.Printf("Created and connected to Switch 2 Pro device %s on bus %d\n", addResp.DevID, addResp.BusID)
+
+	defer func() {
+		if _, err := api.DeviceRemoveCtx(ctx, stream.BusID, stream.DevID); err != nil {
+			fmt.Printf("DeviceRemove error: %v\n", err)
+		} else {
+			fmt.Printf("Removed device %d-%s\n", addResp.BusID, addResp.DevID)
+		}
+		if createdBus {
+			if _, err := api.BusRemoveCtx(ctx, busID); err != nil {
+				fmt.Printf("BusRemove error: %v\n", err)
+			} else {
+				fmt.Printf("Removed bus %d\n", busID)
+			}
+		}
+	}()
+
+	rumbleCh, errCh := stream.StartReading(ctx, 10, func(r *bufio.Reader) (encoding.BinaryUnmarshaler, error) {
+		var b [ns2pro.OutputWireSize]byte
+		if _, err := io.ReadFull(r, b[:]); err != nil {
+			return nil, err
+		}
+		msg := new(ns2pro.OutputState)
+		if err := msg.UnmarshalBinary(b[:]); err != nil {
+			return nil, err
+		}
+		return msg, nil
+	})
+
+	go func() {
+		for {
+			select {
+			case msg := <-rumbleCh:
+				if msg == nil {
+					continue
+				}
+				rumble := msg.(*ns2pro.OutputState)
+				fmt.Printf("[Output] HD rumble L=% x R=% x\n", rumble.LeftRumble[:6], rumble.RightRumble[:6])
+			case err := <-errCh:
+				if err != nil {
+					fmt.Printf("[Output read error] %v\n", err)
+				}
+				return
+			}
+		}
+	}()
+
+	sigCh := make(chan os.Signal, 1)
+	signal.Notify(sigCh, os.Interrupt, syscall.SIGTERM)
+
+	ticker := time.NewTicker(16 * time.Millisecond)
+	defer ticker.Stop()
+
+	fmt.Println("Switch 2 Pro device active. Press Ctrl+C to exit.")
+	fmt.Println("Demo: left stick circles, face buttons rotate, gyro/accel drift gently.")
+
+	var frame uint64
+	for {
+		select {
+		case <-ticker.C:
+			frame++
+			angle := float64(frame) * 0.045
+
+			state := ns2pro.InputState{
+				Buttons:       demoButtons(frame),
+				LX:            stickAxis(math.Cos(angle)),
+				LY:            stickAxis(math.Sin(angle)),
+				RX:            ns2pro.StickCenter,
+				RY:            ns2pro.StickCenter,
+				AccelX:        int16(800 * math.Sin(angle*0.5)),
+				AccelY:        int16(800 * math.Cos(angle*0.5)),
+				AccelZ:        -4096,
+				GyroX:         int16(500 * math.Sin(angle)),
+				GyroY:         int16(500 * math.Cos(angle)),
+				GyroZ:         int16(250 * math.Sin(angle*0.33)),
+				BatteryLevel:  ns2pro.BatteryMax,
+				ExternalPower: true,
+			}
+
+			if err := stream.WriteBinary(&state); err != nil {
+				fmt.Printf("Send error: %v\n", err)
+				return
+			}
+
+			if frame%60 == 0 {
+				fmt.Printf("→ Sent frame %d buttons=0x%06x LX=%04x LY=%04x Gyro=(%d,%d,%d)\n",
+					frame, state.Buttons, state.LX, state.LY, state.GyroX, state.GyroY, state.GyroZ)
+			}
+
+		case <-sigCh:
+			fmt.Println("\nShutting down...")
+			return
+		}
+	}
+}
+
+func findOrCreateBus(ctx context.Context, api *viiperclient.Client) (uint32, bool, error) {
+	busesResp, err := api.BusListCtx(ctx)
+	if err != nil {
+		return 0, false, err
+	}
+
+	if len(busesResp.Buses) == 0 {
+		r, err := api.BusCreateCtx(ctx, 0)
+		if err != nil {
+			return 0, false, err
+		}
+		fmt.Printf("Created bus %d\n", r.BusID)
+		return r.BusID, true, nil
+	}
+
+	busID := busesResp.Buses[0]
+	for _, b := range busesResp.Buses[1:] {
+		if b < busID {
+			busID = b
+		}
+	}
+	fmt.Printf("Using existing bus %d\n", busID)
+	return busID, false, nil
+}
+
+func demoButtons(frame uint64) uint32 {
+	switch (frame / 60) % 6 {
+	case 0:
+		return ns2pro.ButtonA
+	case 1:
+		return ns2pro.ButtonB
+	case 2:
+		return ns2pro.ButtonX
+	case 3:
+		return ns2pro.ButtonY
+	case 4:
+		return ns2pro.ButtonL | ns2pro.ButtonR
+	default:
+		return ns2pro.ButtonZL | ns2pro.ButtonZR
+	}
+}
+
+func stickAxis(v float64) uint16 {
+	const radius = 1400.0
+	raw := float64(ns2pro.StickCenter) + radius*v
+	if raw < float64(ns2pro.StickMin) {
+		return ns2pro.StickMin
+	}
+	if raw > float64(ns2pro.StickMax) {
+		return ns2pro.StickMax
+	}
+	return uint16(raw)
+}

--- a/internal/registry/devices.go
+++ b/internal/registry/devices.go
@@ -4,5 +4,6 @@ import (
 	_ "github.com/Alia5/VIIPER/device/dualshock4"
 	_ "github.com/Alia5/VIIPER/device/keyboard"
 	_ "github.com/Alia5/VIIPER/device/mouse"
+	_ "github.com/Alia5/VIIPER/device/ns2pro"
 	_ "github.com/Alia5/VIIPER/device/xbox360"
 )

--- a/internal/server/usb/descriptor_test.go
+++ b/internal/server/usb/descriptor_test.go
@@ -1,0 +1,70 @@
+package usb
+
+import (
+	"bytes"
+	"encoding/binary"
+	"testing"
+
+	usbdesc "github.com/Alia5/VIIPER/usb"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestBuildConfigDescriptorSupportsIADAndAlternateSettings(t *testing.T) {
+	desc := &usbdesc.Descriptor{
+		Configuration: usbdesc.ConfigurationDescriptor{
+			BConfigurationValue: 0x01,
+			IConfiguration:      0x04,
+			BMAttributes:        0xC0,
+			BMaxPower:           0xFA,
+		},
+		Associations: []usbdesc.InterfaceAssociationDescriptor{
+			{BFirstInterface: 0, BInterfaceCount: 1, BFunctionClass: 0x03},
+			{BFirstInterface: 1, BInterfaceCount: 2, BFunctionClass: 0x01, BFunctionSubClass: 0x01},
+		},
+		Interfaces: []usbdesc.InterfaceConfig{
+			{
+				Descriptor: usbdesc.InterfaceDescriptor{
+					BInterfaceNumber: 0, BNumEndpoints: 1, BInterfaceClass: 0x03,
+				},
+				Endpoints: []usbdesc.EndpointDescriptor{{BEndpointAddress: 0x81, BMAttributes: 0x03, WMaxPacketSize: 64, BInterval: 4}},
+			},
+			{
+				Descriptor: usbdesc.InterfaceDescriptor{
+					BInterfaceNumber: 1, BAlternateSetting: 0, BInterfaceClass: 0x01, BInterfaceSubClass: 0x02,
+				},
+			},
+			{
+				Descriptor: usbdesc.InterfaceDescriptor{
+					BInterfaceNumber: 1, BAlternateSetting: 1, BNumEndpoints: 1, BInterfaceClass: 0x01, BInterfaceSubClass: 0x02,
+				},
+				Endpoints: []usbdesc.EndpointDescriptor{{
+					BEndpointAddress: 0x03,
+					BMAttributes:     0x0D,
+					WMaxPacketSize:   0x00C0,
+					BInterval:        1,
+					ClassDescriptors: []usbdesc.ClassSpecificDescriptor{
+						{DescriptorType: 0x25, Payload: usbdesc.Data{0x01, 0x00, 0x00, 0x00, 0x00}},
+					},
+				}},
+			},
+			{
+				Descriptor: usbdesc.InterfaceDescriptor{
+					BInterfaceNumber: 2, BAlternateSetting: 0, BInterfaceClass: 0x01, BInterfaceSubClass: 0x02,
+				},
+			},
+		},
+	}
+
+	got := (&Server{}).buildConfigDescriptor(desc)
+	require.NotEmpty(t, got)
+	assert.Equal(t, uint16(len(got)), binary.LittleEndian.Uint16(got[2:4]))
+	assert.Equal(t, byte(3), got[4])
+	assert.Equal(t, byte(0x01), got[5])
+	assert.Equal(t, byte(0x04), got[6])
+	assert.Equal(t, byte(0xC0), got[7])
+	assert.Equal(t, byte(0xFA), got[8])
+
+	assert.Equal(t, []byte{0x08, 0x0B, 0x00, 0x01, 0x03, 0x00, 0x00, 0x00}, got[9:17])
+	assert.True(t, bytes.Contains(got, []byte{0x07, 0x25, 0x01, 0x00, 0x00, 0x00, 0x00}))
+}

--- a/internal/server/usb/server.go
+++ b/internal/server/usb/server.go
@@ -691,6 +691,11 @@ func (s *Server) handleUrbStream(conn net.Conn, dev usb.Device) error {
 				return fmt.Errorf("write RET_SUBMIT payload: %w", err)
 			}
 		}
+		if bw != nil && ep == 0 {
+			if err := bw.Flush(); err != nil {
+				return fmt.Errorf("flush EP0 response: %w", err)
+			}
+		}
 		_ = xferFlags
 		_ = devid
 	}
@@ -778,8 +783,9 @@ func (s *Server) processSubmit(dev usb.Device, ep uint32, dir uint32, setup []by
 	}
 
 	if desc.MicrosoftOS10 != nil &&
-		breq == desc.MicrosoftOS10.EffectiveVendorCode() &&
-		(bm == 0xC0 || bm == 0xC1) {
+		(bm == 0xC0 || bm == 0xC1) &&
+		(breq == desc.MicrosoftOS10.EffectiveVendorCode() ||
+			wIndex == 0x0004 || wIndex == 0x0005) {
 		if data, ok := desc.MicrosoftOS10.ControlResponse(wValue, wIndex); ok {
 			if int(wLength) < len(data) {
 				return data[:wLength]

--- a/internal/server/usb/server.go
+++ b/internal/server/usb/server.go
@@ -456,10 +456,10 @@ func (s *Server) handleDevList(conn net.Conn) error {
 			BDeviceProtocol:     desc.Device.BDeviceProtocol,
 			BConfigurationValue: usbConfigValueDefault,
 			BNumConfigurations:  desc.Device.BNumConfigurations,
-			BNumInterfaces:      uint8(len(desc.Interfaces)),
+			BNumInterfaces:      desc.NumInterfaces(),
 		}
 
-		for _, iface := range desc.Interfaces {
+		for _, iface := range descriptorListInterfaces(desc) {
 			exp.Interfaces = append(exp.Interfaces, usbip.InterfaceDesc{
 				Class:    iface.Descriptor.BInterfaceClass,
 				SubClass: iface.Descriptor.BInterfaceSubClass,
@@ -512,9 +512,9 @@ func (s *Server) handleImport(conn net.Conn) (usb.Device, error) {
 		BDeviceProtocol:     chosenDesc.Device.BDeviceProtocol,
 		BConfigurationValue: usbConfigValueDefault,
 		BNumConfigurations:  chosenDesc.Device.BNumConfigurations,
-		BNumInterfaces:      uint8(len(chosenDesc.Interfaces)),
+		BNumInterfaces:      chosenDesc.NumInterfaces(),
 	}
-	for _, iface := range chosenDesc.Interfaces {
+	for _, iface := range descriptorListInterfaces(chosenDesc) {
 		exp.Interfaces = append(exp.Interfaces, usbip.InterfaceDesc{
 			Class:    iface.Descriptor.BInterfaceClass,
 			SubClass: iface.Descriptor.BInterfaceSubClass,
@@ -762,7 +762,9 @@ func (s *Server) processSubmit(dev usb.Device, ep uint32, dir uint32, setup []by
 		case usbDescTypeConfiguration:
 			data = s.buildConfigDescriptor(desc)
 		case usbDescTypeString:
-			if s, ok := desc.Strings[dindex]; ok {
+			if dindex == 0xEE && desc.MicrosoftOS10 != nil {
+				data = desc.MicrosoftOS10.StringDescriptor()
+			} else if s, ok := desc.Strings[dindex]; ok {
 				data = usb.EncodeStringDescriptor(s)
 			}
 		}
@@ -774,12 +776,23 @@ func (s *Server) processSubmit(dev usb.Device, ep uint32, dir uint32, setup []by
 		}
 		return data
 	}
+
+	if desc.MicrosoftOS10 != nil &&
+		breq == desc.MicrosoftOS10.EffectiveVendorCode() &&
+		(bm == 0xC0 || bm == 0xC1) {
+		if data, ok := desc.MicrosoftOS10.ControlResponse(wValue, wIndex); ok {
+			if int(wLength) < len(data) {
+				return data[:wLength]
+			}
+			return data
+		}
+	}
+
 	if breq == usbReqGetDescriptor && bm == usbReqTypeStandardToInterface {
 		dtype := uint8(wValue >> 8)
 		iface := uint8(wIndex & 0xff)
 		var data []byte
-		if int(iface) < len(desc.Interfaces) {
-			ifaceConf := desc.Interfaces[iface]
+		if ifaceConf, ok := desc.Interface(iface); ok {
 			if ifaceConf.HID != nil {
 				switch dtype {
 				case usbDescTypeHID:
@@ -854,16 +867,33 @@ func (s *Server) processSubmit(dev usb.Device, ep uint32, dir uint32, setup []by
 
 func (s *Server) buildConfigDescriptor(desc *usb.Descriptor) []byte {
 	var b bytes.Buffer
+	configValue := desc.Configuration.BConfigurationValue
+	if configValue == 0 {
+		configValue = usbConfigValueDefault
+	}
+	attrs := desc.Configuration.BMAttributes
+	if attrs == 0 {
+		attrs = usbConfigAttrBusPowered
+	}
+	maxPower := desc.Configuration.BMaxPower
+	if maxPower == 0 {
+		maxPower = usbConfigMaxPower100mA
+	}
 	h := usb.ConfigHeader{
 		WTotalLength:        0, // to be patched
-		BNumInterfaces:      uint8(len(desc.Interfaces)),
-		BConfigurationValue: usbConfigValueDefault,
-		IConfiguration:      0,
-		BMAttributes:        usbConfigAttrBusPowered,
-		BMaxPower:           usbConfigMaxPower100mA,
+		BNumInterfaces:      desc.NumInterfaces(),
+		BConfigurationValue: configValue,
+		IConfiguration:      desc.Configuration.IConfiguration,
+		BMAttributes:        attrs,
+		BMaxPower:           maxPower,
 	}
 	h.Write(&b)
 	for _, iface := range desc.Interfaces {
+		for _, iad := range desc.Associations {
+			if iad.BFirstInterface == iface.Descriptor.BInterfaceNumber && iface.Descriptor.BAlternateSetting == 0 {
+				iad.Write(&b)
+			}
+		}
 		iface.Descriptor.Write(&b)
 		if iface.HID != nil {
 			hd, err := iface.HID.DescriptorBytes()
@@ -879,10 +909,35 @@ func (s *Server) buildConfigDescriptor(desc *usb.Descriptor) []byte {
 		}
 		for _, ep := range iface.Endpoints {
 			ep.Write(&b)
+			for _, cd := range ep.ClassDescriptors {
+				b.Write([]byte(cd.Bytes()))
+			}
 		}
 	}
 
 	data := b.Bytes()
 	binary.LittleEndian.PutUint16(data[2:4], uint16(len(data)))
 	return data
+}
+
+func descriptorListInterfaces(desc *usb.Descriptor) []usb.InterfaceConfig {
+	out := make([]usb.InterfaceConfig, 0, desc.NumInterfaces())
+	seen := map[uint8]struct{}{}
+	for _, iface := range desc.Interfaces {
+		n := iface.Descriptor.BInterfaceNumber
+		if _, ok := seen[n]; ok || iface.Descriptor.BAlternateSetting != 0 {
+			continue
+		}
+		seen[n] = struct{}{}
+		out = append(out, iface)
+	}
+	for _, iface := range desc.Interfaces {
+		n := iface.Descriptor.BInterfaceNumber
+		if _, ok := seen[n]; ok {
+			continue
+		}
+		seen[n] = struct{}{}
+		out = append(out, iface)
+	}
+	return out
 }

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -83,6 +83,7 @@ nav:
 - Devices:
   - Xbox 360 Controller: devices/xbox360.md
   - DualShock 4 Controller: devices/dualshock4.md
+  - Switch 2 Pro Controller: devices/ns2pro.md
   - Keyboard: devices/keyboard.md
   - Mouse: devices/mouse.md
 - Community & Support: misc/support.md

--- a/usb/usbdesc.go
+++ b/usb/usbdesc.go
@@ -5,6 +5,7 @@ import (
 	"bytes"
 	"encoding/binary"
 	"fmt"
+	"unicode/utf16"
 
 	"github.com/Alia5/VIIPER/usb/hid"
 )
@@ -15,6 +16,7 @@ const (
 	ConfigDescType    = 0x02
 	InterfaceDescType = 0x04
 	EndpointDescType  = 0x05
+	IADDescType       = 0x0B
 	HIDDescType       = 0x21
 	ReportDescType    = 0x22
 )
@@ -23,6 +25,7 @@ const (
 const (
 	DeviceDescLen    = 18
 	ConfigDescLen    = 9
+	IADDescLen       = 8
 	InterfaceDescLen = 9
 	EndpointDescLen  = 7
 	HIDDescLen       = 9
@@ -32,9 +35,147 @@ type Data []uint8
 
 // Descriptor holds all static descriptor/config data for a device.
 type Descriptor struct {
-	Device     DeviceDescriptor
-	Interfaces []InterfaceConfig
-	Strings    map[uint8]string
+	Device        DeviceDescriptor
+	Configuration ConfigurationDescriptor
+	MicrosoftOS10 *MicrosoftOS10Descriptor
+	Associations  []InterfaceAssociationDescriptor
+	Interfaces    []InterfaceConfig
+	Strings       map[uint8]string
+}
+
+// MicrosoftOS10Descriptor enables the Microsoft OS 1.0 descriptor probe used by
+// Windows to bind vendor-specific interfaces to inbox drivers such as WinUSB.
+type MicrosoftOS10Descriptor struct {
+	VendorCode          uint8
+	InterfaceNumber     uint8
+	CompatibleID        string
+	SubCompatibleID     string
+	DeviceInterfaceGUID string
+}
+
+func (d MicrosoftOS10Descriptor) StringDescriptor() []byte {
+	return []byte{
+		0x12, 0x03,
+		'M', 0x00,
+		'S', 0x00,
+		'F', 0x00,
+		'T', 0x00,
+		'1', 0x00,
+		'0', 0x00,
+		'0', 0x00,
+		d.EffectiveVendorCode(), 0x00,
+	}
+}
+
+func (d MicrosoftOS10Descriptor) EffectiveVendorCode() uint8 {
+	if d.VendorCode == 0 {
+		return 0x20
+	}
+	return d.VendorCode
+}
+
+func (d MicrosoftOS10Descriptor) ControlResponse(wValue, wIndex uint16) ([]byte, bool) {
+	switch {
+	case wIndex == 0x0004:
+		return d.CompatibleIDDescriptor(), true
+	case wIndex == 0x0005 || wValue == 0x0005:
+		return d.ExtendedPropertiesDescriptor(), true
+	default:
+		return nil, false
+	}
+}
+
+func (d MicrosoftOS10Descriptor) CompatibleIDDescriptor() []byte {
+	out := make([]byte, 40)
+	binary.LittleEndian.PutUint32(out[0:4], uint32(len(out)))
+	binary.LittleEndian.PutUint16(out[4:6], 0x0100)
+	binary.LittleEndian.PutUint16(out[6:8], 0x0004)
+	out[8] = 0x01
+	out[16] = d.InterfaceNumber
+	copyFixedASCII(out[18:26], d.CompatibleID)
+	copyFixedASCII(out[26:34], d.SubCompatibleID)
+	return out
+}
+
+func (d MicrosoftOS10Descriptor) ExtendedPropertiesDescriptor() []byte {
+	if d.DeviceInterfaceGUID == "" {
+		out := make([]byte, 10)
+		binary.LittleEndian.PutUint32(out[0:4], uint32(len(out)))
+		binary.LittleEndian.PutUint16(out[4:6], 0x0100)
+		binary.LittleEndian.PutUint16(out[6:8], 0x0005)
+		return out
+	}
+
+	name := utf16leString("DeviceInterfaceGUID")
+	data := utf16leString(d.DeviceInterfaceGUID)
+
+	sectionLen := 4 + 4 + 2 + len(name) + 4 + len(data)
+	out := make([]byte, 10+sectionLen)
+	binary.LittleEndian.PutUint32(out[0:4], uint32(len(out)))
+	binary.LittleEndian.PutUint16(out[4:6], 0x0100)
+	binary.LittleEndian.PutUint16(out[6:8], 0x0005)
+	binary.LittleEndian.PutUint16(out[8:10], 0x0001)
+
+	off := 10
+	binary.LittleEndian.PutUint32(out[off:off+4], uint32(sectionLen))
+	off += 4
+	binary.LittleEndian.PutUint32(out[off:off+4], 0x00000001) // REG_SZ
+	off += 4
+	binary.LittleEndian.PutUint16(out[off:off+2], uint16(len(name)))
+	off += 2
+	copy(out[off:off+len(name)], name)
+	off += len(name)
+	binary.LittleEndian.PutUint32(out[off:off+4], uint32(len(data)))
+	off += 4
+	copy(out[off:], data)
+	return out
+}
+
+func copyFixedASCII(dst []byte, s string) {
+	for i := range dst {
+		dst[i] = 0
+	}
+	copy(dst, []byte(s))
+}
+
+func utf16leString(s string) []byte {
+	units := utf16.Encode([]rune(s + "\x00"))
+	out := make([]byte, len(units)*2)
+	for i, u := range units {
+		binary.LittleEndian.PutUint16(out[i*2:i*2+2], u)
+	}
+	return out
+}
+
+// NumInterfaces returns the number of distinct interface numbers in the active
+// configuration. Alternate settings share the same interface number and only
+// count once in the USB configuration descriptor header.
+func (d Descriptor) NumInterfaces() uint8 {
+	seen := map[uint8]struct{}{}
+	for _, iface := range d.Interfaces {
+		seen[iface.Descriptor.BInterfaceNumber] = struct{}{}
+	}
+	return uint8(len(seen))
+}
+
+// Interface returns the first matching interface descriptor for an interface
+// number, preferring alternate setting zero when available.
+func (d Descriptor) Interface(number uint8) (InterfaceConfig, bool) {
+	var found InterfaceConfig
+	ok := false
+	for _, iface := range d.Interfaces {
+		if iface.Descriptor.BInterfaceNumber != number {
+			continue
+		}
+		if iface.Descriptor.BAlternateSetting == 0 {
+			return iface, true
+		}
+		if !ok {
+			found = iface
+			ok = true
+		}
+	}
+	return found, ok
 }
 
 // InterfaceConfig holds all descriptors for a single interface for bus management.
@@ -122,6 +263,37 @@ type ConfigHeader struct {
 	BMaxPower           uint8
 }
 
+// ConfigurationDescriptor contains the non-derived fields from the USB
+// configuration descriptor. Zero values keep the server defaults.
+type ConfigurationDescriptor struct {
+	BConfigurationValue uint8
+	IConfiguration      uint8
+	BMAttributes        uint8
+	BMaxPower           uint8
+}
+
+// InterfaceAssociationDescriptor describes a USB Interface Association
+// Descriptor (IAD), used by composite devices to group related interfaces.
+type InterfaceAssociationDescriptor struct {
+	BFirstInterface   uint8
+	BInterfaceCount   uint8
+	BFunctionClass    uint8
+	BFunctionSubClass uint8
+	BFunctionProtocol uint8
+	IFunction         uint8
+}
+
+func (i InterfaceAssociationDescriptor) Write(b *bytes.Buffer) {
+	b.WriteByte(IADDescLen)
+	b.WriteByte(IADDescType)
+	b.WriteByte(i.BFirstInterface)
+	b.WriteByte(i.BInterfaceCount)
+	b.WriteByte(i.BFunctionClass)
+	b.WriteByte(i.BFunctionSubClass)
+	b.WriteByte(i.BFunctionProtocol)
+	b.WriteByte(i.IFunction)
+}
+
 func (h ConfigHeader) Write(b *bytes.Buffer) {
 	b.WriteByte(ConfigDescLen)
 	b.WriteByte(ConfigDescType)
@@ -164,6 +336,10 @@ type EndpointDescriptor struct {
 	BMAttributes     uint8
 	WMaxPacketSize   uint16 // LE
 	BInterval        uint8
+
+	// ClassDescriptors are optional endpoint-level class-specific descriptors
+	// emitted immediately after this endpoint descriptor.
+	ClassDescriptors []ClassSpecificDescriptor
 }
 
 func (e EndpointDescriptor) Write(b *bytes.Buffer) {


### PR DESCRIPTION
## Description
Adds Nintendo Switch 2 Pro / NS2 Pro virtual USB HID device support to VIIPER.

This includes the NS2 Pro device implementation, input state and output feedback handling, USB/HID descriptors for host recognition, registry integration for the API device type `ns2pro`, a focused Go example, and device documentation.

## Related Issue
N/A

## Motivation and Context
This change lets VIIPER create a virtual Nintendo Switch 2 Pro Controller over USB so host-side software can interact with it through the existing VIIPER API and device streaming model.

## How Has This Been Tested?
- [x] Unit tests
- [x] `go test ./...`
- [x] Targeted tests for `device/ns2pro`, `internal/server/usb`, `device`, and `internal/server/api/handler`

## Type of Change
- [ ] Bug fix (non-breaking change addressing an issue)
- [x] New feature (non-breaking change adding functionality)
- [ ] Breaking change (fix or feature causing existing functionality to change)
- [x] Documentation update

## Checklist
- [x] My code follows the code style of this project
- [x] I have updated the documentation accordingly
- [x] I have added tests to cover my changes
- [x] All new and existing tests passed