### PR TITLE
Added quotes around paths for libVIIPER dir check in Makefile

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -165,7 +165,7 @@ LIBVIIPER_DIST_DIR := dist/libVIIPER
 .PHONY: libVIIPER
 libVIIPER:
 ifeq ($(OS),Windows_NT)
-	@if not exist $(LIBVIIPER_DIST_DIR) mkdir $(LIBVIIPER_DIST_DIR)
+	@if not exist "$(LIBVIIPER_DIST_DIR)" mkdir "$(LIBVIIPER_DIST_DIR)"
 	@go install github.com/josephspurrier/goversioninfo/cmd/goversioninfo@latest
 	@powershell -NoProfile -NonInteractive -File scripts/inject-version.ps1 "$(VERSION)" "$(LIBVIIPER_VERSIONINFO_JSON)" "libviiper.versioninfo.tmp.json"
 	@cd $(SRC_DIR) && goversioninfo -64 -o $(LIBVIIPER_RESOURCE_SYSO) libviiper.versioninfo.tmp.json


### PR DESCRIPTION
## Description

`make libVIIPER` did not work on my end as it would complain about a command syntax error. The problem went away when the path in the **LIBVIIPER_DIST_DIR** var was put in quotes.

## How Has This Been Tested?

- [x] Tested with hardware (specify configuration)
- [ ] Unit tests
- [ ] Code review only

## Type of Change

- [x] Bug fix (non-breaking change addressing an issue)
- [ ] New feature (non-breaking change adding functionality)
- [ ] Breaking change (fix or feature causing existing functionality to change)
- [ ] Documentation update

## Checklist

- [x] My code follows the code style of this project
- [ ] I have updated the documentation accordingly
- [ ] I have added tests to cover my changes
- [ ] All new and existing tests passed
