### PR TITLE
Added ldflags to remove debug info when compiling libVIIPER library using go

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -170,7 +170,7 @@ ifeq ($(OS),Windows_NT)
 	@powershell -NoProfile -NonInteractive -File scripts/inject-version.ps1 "$(VERSION)" "$(LIBVIIPER_VERSIONINFO_JSON)" "libviiper.versioninfo.tmp.json"
 	@cd $(SRC_DIR) && goversioninfo -64 -o $(LIBVIIPER_RESOURCE_SYSO) libviiper.versioninfo.tmp.json
 	@del libviiper.versioninfo.tmp.json
-	set CGO_ENABLED=1 && go build -buildmode=c-shared -o $(LIBVIIPER_DIST_DIR)/libVIIPER.dll ./lib/viiper
+	set CGO_ENABLED=1 && go build -buildmode=c-shared -ldflags="-s -w" -o $(LIBVIIPER_DIST_DIR)/libVIIPER.dll ./lib/viiper
 	cd $(LIBVIIPER_DIST_DIR) && gendef libVIIPER.dll
 	go run ./lib/viiper/postbuild
 else


### PR DESCRIPTION
## Description

More of an optimization than a problem. There is a performance difference in the compiled library when explicitly passing ldflags to go. Tested using the Steam Controller 2026 emulating a DS4 for playing Resident Evil 1 classic from GOG.

## Motivation and Context

Trying to optimize things and adding the ldflags improved the runtime performance of libVIIPER.dll by a lot

## How Has This Been Tested?
<!-- Please describe how you tested your changes -->
- [x] Tested with hardware (specify configuration)
- [ ] Unit tests
- [ ] Code review only

## Type of Change
<!-- What types of changes does your code introduce? Put an `x` in all boxes that apply -->
- [ ] Bug fix (non-breaking change addressing an issue)
- [x] New feature (non-breaking change adding functionality)
- [ ] Breaking change (fix or feature causing existing functionality to change)
- [ ] Documentation update

## Checklist
<!-- Put an `x` in all the boxes that apply -->
- [x] My code follows the code style of this project
- [ ] I have updated the documentation accordingly
- [ ] I have added tests to cover my changes
- [ ] All new and existing tests passed
